### PR TITLE
Impl/00 codeguide sibling mode

### DIFF
--- a/plugins/codeguide/scripts/_sibling.py
+++ b/plugins/codeguide/scripts/_sibling.py
@@ -1,0 +1,73 @@
+"""
+Sibling-path resolver: maps a (role, repo_root) pair to the canonical
+location of an adjacent sibling directory or repo.
+
+Hub-form vs prefix-form
+-----------------------
+If ``repo_root.name == "hub"`` (exact, case-sensitive), the repo is in
+*hub-form*: siblings live as bare names next to it.
+
+    <container>/hub/
+    <container>/worktrees/
+    <container>/wiki/
+    <container>/codeguide/
+
+Otherwise (*prefix-form*) siblings carry the repo's name as a prefix so
+multiple repos can share the same parent directory without collision.
+
+    <container>/foo/
+    <container>/foo.worktrees/
+    <container>/foo.wiki/
+    <container>/foo.codeguide/
+
+Hub-form detection is deliberately literal — ``Hub/`` or ``HUB/`` fall
+through to prefix-form. Zero heuristics keeps the rule predictable.
+
+Identical-twin rule
+-------------------
+This file is a deliberate duplicate of ``plugins/mill/scripts/_sibling.py``.
+Each plugin carries its own copy to avoid any cross-plugin import
+assumption: plugin install paths are not guaranteed to be relative
+siblings of each other, so ``${CLAUDE_PLUGIN_ROOT}/../mill/scripts/...``
+cannot be relied upon. If you edit one, grep for the other and apply the
+same change.
+
+Usage
+-----
+Python::
+
+    from _sibling import resolve_path
+    resolve_path("codeguide", Path("/c/Code/millhouse/hub"))
+    # -> Path("/c/Code/millhouse/codeguide")
+
+CLI (for SKILL.md prose / subprocess callers)::
+
+    python _sibling.py codeguide /c/Code/millhouse/hub
+    # prints: /c/Code/millhouse/codeguide
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def resolve_path(role: str, repo_root: Path) -> Path:
+    repo_root = Path(repo_root)
+    parent = repo_root.parent
+    if repo_root.name == "hub":
+        return parent / role
+    return parent / f"{repo_root.name}.{role}"
+
+
+def _main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print("usage: _sibling.py <role> <repo_root>", file=sys.stderr)
+        return 2
+    role = argv[1]
+    repo_root = Path(argv[2])
+    print(resolve_path(role, repo_root))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv))

--- a/plugins/codeguide/scripts/codeguide_commit.py
+++ b/plugins/codeguide/scripts/codeguide_commit.py
@@ -1,0 +1,97 @@
+"""
+Mode-aware staging/commit helper for codeguide.
+
+Usage
+-----
+Inline mode — stage files in the current repo (caller's cwd); the outer
+@git-commit skill will commit them as part of the source-code commit::
+
+    python codeguide_commit.py --mode inline --file <path> [--file <path> ...] -m "<msg>"
+
+Sibling mode — stage AND commit files inside the sibling repo, which has
+its own git history independent of the target repo::
+
+    python codeguide_commit.py --mode sibling --sibling-anchor <path> --file <path> [--file <path> ...] -m "<msg>"
+
+The caller (codeguide-update) already holds ``mode`` and
+``sibling_anchor`` from its own ``resolve.py`` call. Those are passed
+explicitly so this helper does NOT re-run resolve.py (which would be
+fragile if cwd differs from the repo root and couples commit-time
+behavior to import-time side effects).
+
+Output
+------
+Stdout: one-line JSON summary ``{"mode": ..., "committed": true|false, "files": [...]}``.
+Stderr: subprocess transcripts on failure.
+
+Exit codes
+----------
+0 — success
+1 — git subprocess failed
+2 — argument validation failed
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> int:
+    result = subprocess.run(cmd, cwd=str(cwd) if cwd else None, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"$ {' '.join(cmd)}", file=sys.stderr)
+        if result.stdout:
+            print(result.stdout, file=sys.stderr)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+    return result.returncode
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(prog="codeguide_commit.py", add_help=True)
+    ap.add_argument("--mode", choices=("inline", "sibling"), required=True)
+    ap.add_argument("--sibling-anchor", type=Path, default=None)
+    ap.add_argument("--file", action="append", dest="files", default=[], type=Path)
+    ap.add_argument("-m", "--message", required=True)
+    ns = ap.parse_args(argv)
+    if ns.mode == "sibling" and ns.sibling_anchor is None:
+        ap.error("--mode sibling requires --sibling-anchor")
+    if not ns.files:
+        ap.error("at least one --file is required")
+    return ns
+
+
+def main(argv: list[str]) -> int:
+    try:
+        ns = _parse(argv)
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else 2
+
+    files = [str(f) for f in ns.files]
+
+    if ns.mode == "inline":
+        rc = _run(["git", "add", "--"] + files)
+        if rc != 0:
+            print(json.dumps({"mode": "inline", "committed": False, "files": files}))
+            return 1
+        print(json.dumps({"mode": "inline", "committed": False, "files": files}))
+        return 0
+
+    anchor = ns.sibling_anchor
+    rc = _run(["git", "-C", str(anchor), "add", "--"] + files)
+    if rc != 0:
+        print(json.dumps({"mode": "sibling", "committed": False, "files": files}))
+        return 1
+    rc = _run(["git", "-C", str(anchor), "commit", "-m", ns.message])
+    if rc != 0:
+        print(json.dumps({"mode": "sibling", "committed": False, "files": files}))
+        return 1
+    print(json.dumps({"mode": "sibling", "committed": True, "files": files}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/plugins/codeguide/scripts/resolve.py
+++ b/plugins/codeguide/scripts/resolve.py
@@ -1,18 +1,29 @@
 """
 Path resolution for codeguide hooks.
 
-Two-tier resolution:
-- Routing files (Overview.md, modules/) resolve from cwd — each folder with
-  a _codeguide/ is a self-contained routing node.
-- Metadata files (config.yaml, local-rules.md, DocumentationGuide.md)
-  resolve by walking up from cwd to the nearest ancestor that contains
-  them. These are repo-level concerns.
+Resolve chain
+-------------
+1. **Inline walk** — from cwd up to (and including) git-toplevel, look
+   for ``_codeguide/<filename>``.
+2. **.codeguide-root override** — if inline fails, read the first line of
+   ``<git-toplevel>/.codeguide-root`` and use it as the sibling anchor
+   (absolute path, or relative to toplevel).
+3. **Sibling default** — otherwise compute the anchor via
+   ``_sibling.resolve_path("codeguide", git_toplevel)``.
+4. **Sibling walk** — mirror the inline walk under the anchor: for each
+   level from cwd up to toplevel, check
+   ``<anchor>/<rel>/_codeguide/<filename>``.
+
+Routing files (Overview.md, modules/) resolve from cwd — each folder with
+a _codeguide/ is a self-contained routing node.
+Metadata files (config.yaml, local-rules.md, DocumentationGuide.md)
+resolve via the chain above.
 """
 
 import os
 import pathlib
+import sys
 
-# Metadata file that anchors the walk-up search. Change here if renamed.
 METADATA_ANCHOR = "config.yaml"
 
 
@@ -21,28 +32,111 @@ def routing_root(cwd: str | None = None) -> pathlib.Path:
     return pathlib.Path(cwd or os.getcwd()) / "_codeguide"
 
 
-def find_metadata(filename: str, cwd: str | None = None) -> pathlib.Path | None:
-    """Walk up from cwd to find _codeguide/<filename>. Stops at git root."""
-    current = pathlib.Path(cwd or os.getcwd()).resolve()
+def _find_git_toplevel(start: pathlib.Path) -> pathlib.Path | None:
+    current = start.resolve()
     while True:
-        candidate = current / "_codeguide" / filename
-        if candidate.exists():
-            return candidate
         if (current / ".git").exists():
-            return None
+            return current
         parent = current.parent
         if parent == current:
             return None
         current = parent
 
 
+def _walk_levels(cwd: pathlib.Path, toplevel: pathlib.Path) -> list[pathlib.Path]:
+    """Levels from cwd up to and including toplevel."""
+    levels: list[pathlib.Path] = []
+    current = cwd.resolve()
+    toplevel = toplevel.resolve()
+    while True:
+        levels.append(current)
+        if current == toplevel:
+            return levels
+        parent = current.parent
+        if parent == current:
+            return levels
+        current = parent
+
+
+def _inline_walk(filename: str, cwd: pathlib.Path, toplevel: pathlib.Path) -> pathlib.Path | None:
+    for level in _walk_levels(cwd, toplevel):
+        candidate = level / "_codeguide" / filename
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _sibling_walk(filename: str, cwd: pathlib.Path, toplevel: pathlib.Path, anchor: pathlib.Path) -> pathlib.Path | None:
+    toplevel = toplevel.resolve()
+    for level in _walk_levels(cwd, toplevel):
+        rel = level.relative_to(toplevel)
+        candidate = anchor / rel / "_codeguide" / filename
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _read_override(toplevel: pathlib.Path) -> pathlib.Path | None:
+    override = toplevel / ".codeguide-root"
+    if not override.exists():
+        return None
+    raw = override.read_text(encoding="utf-8").strip().splitlines()
+    if not raw:
+        return None
+    anchor = pathlib.Path(raw[0].strip())
+    if not anchor.is_absolute():
+        anchor = (toplevel / anchor).resolve()
+    return anchor
+
+
+def _sibling_anchor_default(toplevel: pathlib.Path) -> pathlib.Path:
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+    from _sibling import resolve_path
+    return resolve_path("codeguide", toplevel)
+
+
+def resolve(cwd: str | None = None, filename: str = METADATA_ANCHOR) -> dict:
+    """Full resolution: inline walk, then .codeguide-root, then sibling default.
+
+    Returns a dict with keys:
+        mode: "inline" | "sibling" | None
+        cg_root: Path | None — the _codeguide/ directory that contains <filename>
+        sibling_anchor: Path | None — the sibling-repo root (only meaningful when mode == "sibling")
+        found: bool
+    """
+    cwd_path = pathlib.Path(cwd or os.getcwd()).resolve()
+    toplevel = _find_git_toplevel(cwd_path)
+    if toplevel is None:
+        return {"mode": None, "cg_root": None, "sibling_anchor": None, "found": False}
+
+    hit = _inline_walk(filename, cwd_path, toplevel)
+    if hit is not None:
+        return {"mode": "inline", "cg_root": hit.parent, "sibling_anchor": None, "found": True}
+
+    anchor = _read_override(toplevel) or _sibling_anchor_default(toplevel)
+    hit = _sibling_walk(filename, cwd_path, toplevel, anchor)
+    if hit is not None:
+        return {"mode": "sibling", "cg_root": hit.parent, "sibling_anchor": anchor, "found": True}
+
+    return {"mode": None, "cg_root": None, "sibling_anchor": anchor, "found": False}
+
+
+def find_metadata(filename: str, cwd: str | None = None) -> pathlib.Path | None:
+    """Find <filename> under any _codeguide/ (inline or sibling chain)."""
+    r = resolve(cwd, filename)
+    return r["cg_root"] / filename if r["found"] else None
+
+
 def config_path(cwd: str | None = None) -> pathlib.Path | None:
-    """Find the nearest metadata anchor (config.yaml by default)."""
     return find_metadata(METADATA_ANCHOR, cwd)
 
 
+def metadata_root(cwd: str | None = None) -> pathlib.Path | None:
+    r = resolve(cwd)
+    return r["cg_root"] if r["found"] else None
+
+
 def load_config_flag(flag: str, cwd: str | None = None) -> bool:
-    """Read a boolean flag from the nearest config.yaml. Returns False if not found."""
     path = config_path(cwd)
     if path is None:
         return False
@@ -58,14 +152,7 @@ def load_config_flag(flag: str, cwd: str | None = None) -> bool:
     return False
 
 
-def metadata_root(cwd: str | None = None) -> pathlib.Path | None:
-    """Find the nearest _codeguide/ containing the metadata anchor."""
-    path = config_path(cwd)
-    return path.parent if path else None
-
-
 def load_source_extensions(cwd: str | None = None) -> list[str]:
-    """Load source extensions from the nearest config.yaml."""
     path = config_path(cwd)
     if path is None:
         return []
@@ -81,10 +168,28 @@ def load_source_extensions(cwd: str | None = None) -> list[str]:
     return extensions
 
 
+def _cli(argv: list[str]) -> int:
+    import json
+    as_json = "--json" in argv[1:]
+    result = resolve()
+    if as_json:
+        payload = {
+            "mode": result["mode"],
+            "cg_root": str(result["cg_root"]) if result["cg_root"] else None,
+            "sibling_anchor": str(result["sibling_anchor"]) if result["sibling_anchor"] else None,
+            "found": result["found"],
+        }
+        print(json.dumps(payload))
+        return 0 if result["found"] else 1
+    if result["found"]:
+        print(result["cg_root"])
+        return 0
+    print(
+        "ERROR: no _codeguide/ with config.yaml found — run /codeguide-setup first [--sibling]",
+        file=sys.stderr,
+    )
+    return 1
+
+
 if __name__ == "__main__":
-    root = metadata_root()
-    if root:
-        print(root)
-    else:
-        print("ERROR: no _codeguide/ with config.yaml found", file=__import__("sys").stderr)
-        __import__("sys").exit(1)
+    sys.exit(_cli(sys.argv))

--- a/plugins/codeguide/skills/codeguide-generate/SKILL.md
+++ b/plugins/codeguide/skills/codeguide-generate/SKILL.md
@@ -16,7 +16,7 @@ Generate `_codeguide/` documentation for source files that don't have correspond
 
 ## Steps
 
-1. **Find `_codeguide/`:** Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/millpy/codeguide/resolve.py` to locate the nearest `_codeguide/` containing config.yaml. If it exits with an error, stop — run `/codeguide-setup` first.
+1. **Find `_codeguide/`:** Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/resolve.py` to locate the nearest `_codeguide/` containing config.yaml. If it exits with an error, stop — run `/codeguide-setup` first.
 
 2. **Read the Documentation Guide:** Read `_codeguide/modules/DocumentationGuide.md` in full. All docs must follow its structure.
 

--- a/plugins/codeguide/skills/codeguide-maintain/SKILL.md
+++ b/plugins/codeguide/skills/codeguide-maintain/SKILL.md
@@ -30,7 +30,7 @@ Sync existing `_codeguide/` documentation with current source code, Documentatio
 
 ## Steps
 
-1. **Find `_codeguide/`:** Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/millpy/codeguide/resolve.py` to locate the nearest `_codeguide/` containing config.yaml. If it exits with an error, stop — run `/codeguide-setup` first.
+1. **Find `_codeguide/`:** Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/resolve.py` to locate the nearest `_codeguide/` containing config.yaml. If it exits with an error, stop — run `/codeguide-setup` first.
 
 2. **Read the Documentation Guide:** Read `_codeguide/modules/DocumentationGuide.md` in full. This is the authoritative structure.
 

--- a/plugins/codeguide/skills/codeguide-setup/SKILL.md
+++ b/plugins/codeguide/skills/codeguide-setup/SKILL.md
@@ -1,15 +1,22 @@
 ---
 name: codeguide-setup
-description: "Set up, refresh, or activate codeguide. Detects context automatically: first-time root, refresh, or subfolder."
-argument-hint: "[.cs .py .ts]"
+description: "Set up, refresh, or activate codeguide (inline or sibling). Detects context automatically: first-time root, refresh, or subfolder."
+argument-hint: "[--sibling] [--from-url <git-url>] [.cs .py .ts]"
 ---
 
-Set up or refresh codeguide in the current working directory. Detects context automatically. Does **not** commit.
+Set up or refresh codeguide for the current git repo. Two placement modes:
+
+- **Inline** (default): files live inside the target repo, under `<repo>/_codeguide/`. `@git-commit` stages them alongside source changes.
+- **Sibling** (`--sibling`): files live in a separate git repo next to the target repo — `<container>/<repo>.codeguide/` by default, or `<container>/codeguide/` when the target is hub-form (directory named exactly `hub`). The sibling repo has its own history. The target repo is never modified.
+
+In both modes, any source-folder subtree can also carry its own `_codeguide/` (subfolder workspace) that points back to the root via `root.txt`. In sibling mode the subfolder's `_codeguide/` lives under the same relative path inside the sibling repo, not in the target repo.
+
+Does **not** commit in inline mode. Commits in the sibling repo when in sibling mode (the sibling's history is independent).
 
 ## What this creates (first-time root)
 
 ```
-_codeguide/
+<root>/_codeguide/
 ├── config.yaml                    ← source file extensions (you own this)
 ├── local-rules.md                 ← repo-specific doc rules (you own this)
 ├── Overview.md                    ← repo routing table (you own this)
@@ -19,88 +26,116 @@ _codeguide/
     └── DocumentationGuide.md      ← how to write docs (plugin-owned)
 ```
 
+Where `<root>` is either the target repo (inline) or `<sibling-anchor>/<rel-path>/` (sibling).
+
 ## Steps
 
-1. **Detect context:** Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/resolve.py` to find the nearest `_codeguide/` with config.yaml.
+1. **Parse flags from `$ARGUMENTS`:**
+   - `--sibling` → sibling mode
+   - `--from-url <git-url>` → when creating the sibling repo for the first time, `git clone <git-url>` instead of `git init`. Ignored without `--sibling`.
+   - Any tokens starting with `.` (e.g. `.cs .py`) → source extensions for `config.yaml`.
 
-2. **Determine mode:**
-   - Config.yaml not found anywhere → **first-time root setup**
-   - Config.yaml is in cwd's own `_codeguide/` → **root refresh**
-   - Config.yaml is in an ancestor's `_codeguide/`, and cwd has `_codeguide/root.txt` → **subfolder refresh**
-   - Config.yaml is in an ancestor's `_codeguide/`, and either cwd has no `_codeguide/` OR cwd's `_codeguide/` has no `root.txt` → **new subfolder** — report what was found and ask user to confirm before proceeding. (The second case covers half-manual state where an earlier workflow created `_codeguide/Overview.md` or `_codeguide/modules/` without registering the folder as a subfolder workspace.)
+2. **Detect git toplevel:** Run `git rev-parse --show-toplevel`. If not in a git repo, stop with an error.
+
+3. **Resolve existing codeguide state:** Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/resolve.py --json` to locate the nearest `_codeguide/` with config.yaml. Parse the JSON: `{mode, cg_root, sibling_anchor, found}`.
+
+4. **Compute target root** `<root>`:
+   - Inline mode: `<root> = cwd` (first-time root) or whichever folder the resolve result points at.
+   - Sibling mode:
+     - Compute `<sibling-anchor>` by invoking `python ${CLAUDE_PLUGIN_ROOT}/scripts/_sibling.py codeguide <git-toplevel>` via subprocess. Parse the printed path.
+     - If `.codeguide-root` exists at the git-toplevel, use its contents instead (single absolute or relative-to-toplevel path). Do NOT auto-create this file; users who want a non-default anchor write it themselves.
+     - If `<sibling-anchor>` does not exist yet: create it with `git init`, OR `git clone <git-url> <sibling-anchor>` when `--from-url <url>` was given. Then `<root> = <sibling-anchor> / <rel-path>` where `<rel-path> = cwd.relative_to(git-toplevel)`.
+     - If `<sibling-anchor>` already exists and is a git repo: `<root> = <sibling-anchor> / <rel-path>`.
+
+5. **Determine mode (first-time / refresh / subfolder):**
+   - `found == false` AND `<root>` has no `_codeguide/` → **first-time root setup**
+   - `<root>` has `_codeguide/config.yaml` → **root refresh**
+   - `found == true` and `<root>/_codeguide/root.txt` exists → **subfolder refresh**
+   - `found == true` and `<root>` is under an ancestor's `_codeguide/` reach, but `<root>` has no `_codeguide/` OR has one without `root.txt` → **new subfolder** (ask user to confirm before proceeding)
 
 ---
 
 ### First-time root setup
 
-3. **Check prerequisites:** Verify the working directory is a git repo (`.git/` exists). If not, stop with an error.
+6. **Check prerequisites:** Inline → verify cwd's git repo exists. Sibling → verify `<sibling-anchor>` is a git repo (created above if needed).
 
-4. **Read plugin files** from `${CLAUDE_PLUGIN_ROOT}`:
+7. **Read plugin files** from `${CLAUDE_PLUGIN_ROOT}`:
    - `templates/DocumentationGuide.md`
    - `templates/config.yaml`
    - `templates/local-rules.md`
    - `templates/cgignore.md`
    - `templates/cgexclude.md`
+   - `templates/codeguide-overview-starter.md`
 
-5. **Create directories:** Create `_codeguide/modules/`.
+8. **Create directories:** `<root>/_codeguide/modules/`.
 
-6. **Copy plugin-owned files:**
-   - `templates/DocumentationGuide.md` → `_codeguide/modules/DocumentationGuide.md`
+9. **Copy plugin-owned files:**
+   - `templates/DocumentationGuide.md` → `<root>/_codeguide/modules/DocumentationGuide.md`
 
-7. **Create user-owned files** (only if they don't exist):
-   - `_codeguide/cgignore.md` — copy from template (user adds repo-specific entries).
-   - `_codeguide/config.yaml` — if `$ARGUMENTS` contains extensions (args starting with `.`), write a config with those extensions. Otherwise copy the template.
-   - `_codeguide/local-rules.md` — copy from template.
-   - `_codeguide/cgexclude.md` — copy from template.
-   - `_codeguide/Overview.md` — read `${CLAUDE_PLUGIN_ROOT}/templates/codeguide-overview-starter.md`, strip the leading HTML comment, and write the body to `_codeguide/Overview.md`.
+10. **Create user-owned files** (only if they don't exist):
+    - `<root>/_codeguide/cgignore.md` — copy from template (user adds repo-specific entries).
+    - `<root>/_codeguide/config.yaml` — if `$ARGUMENTS` contained extensions, write a config with those extensions. Otherwise copy the template.
+    - `<root>/_codeguide/local-rules.md` — copy from template.
+    - `<root>/_codeguide/cgexclude.md` — copy from template.
+    - `<root>/_codeguide/Overview.md` — read `templates/codeguide-overview-starter.md`, strip the leading HTML comment, and write the body.
 
-8. **Report** what was created.
+11. **Commit (sibling mode only):** In the sibling repo, `git -C <sibling-anchor> add -A && git -C <sibling-anchor> commit -m "codeguide-setup: init <rel-path>"` (use `init root` when `<rel-path>` is empty).
+
+12. **Report** what was created and where (inline vs sibling; print `<root>`).
 
 ---
 
 ### Root refresh
 
-3. **Read plugin source files** from `${CLAUDE_PLUGIN_ROOT}`:
+6. **Read plugin source files** from `${CLAUDE_PLUGIN_ROOT}`:
    - `templates/DocumentationGuide.md`
    - `templates/config.yaml`
 
-4. **Overwrite plugin-owned files:**
-   - `_codeguide/modules/DocumentationGuide.md`
+7. **Overwrite plugin-owned files:**
+   - `<root>/_codeguide/modules/DocumentationGuide.md`
 
-5. **Merge config schema:** For each key in the template that is missing from the repo's `_codeguide/config.yaml`, add it with its default value and comment. Do not change existing values.
+8. **Merge config schema:** For each key in the template that is missing from `<root>/_codeguide/config.yaml`, add it with its default value and comment. Do not change existing values.
 
-6. **Create `_codeguide/cgexclude.md`** if it doesn't exist.
+9. **Create `<root>/_codeguide/cgexclude.md`** if it doesn't exist.
 
-7. **Report** what was updated.
+10. **Commit (sibling mode only):** `codeguide-setup: refresh <rel-path>`.
+
+11. **Report** what was updated.
 
 ---
 
 ### Subfolder refresh
 
-3. **Update `_codeguide/root.txt`** with the current resolved path.
+6. **Update `<root>/_codeguide/root.txt`** with the current resolved path to the root `_codeguide/`.
 
-4. **Create `_codeguide/cgexclude.md`** if it doesn't exist.
+7. **Create `<root>/_codeguide/cgexclude.md`** if it doesn't exist.
 
-5. **Report** what was updated.
+8. **Commit (sibling mode only):** `codeguide-setup: subfolder refresh <rel-path>`.
+
+9. **Report** what was updated.
 
 ---
 
 ### New subfolder activation
 
-3. **Report findings:** "Found repo-level `_codeguide/` at `<path>`." If cwd already has a `_codeguide/` directory without `root.txt`, add: "cwd already has `_codeguide/` with files: `<list>`. Promote this folder to a subfolder workspace without touching existing files?" Otherwise: "Set up this folder as a subfolder workspace?"
+6. **Report findings:** "Found root `_codeguide/` at `<path>` (mode: inline|sibling)." If `<root>` already has a `_codeguide/` directory without `root.txt`, add: "`<root>` already has `_codeguide/` with files: `<list>`. Promote this folder to a subfolder workspace without touching existing files?" Otherwise: "Set up this folder as a subfolder workspace?"
 
-4. **Wait for user confirmation.** If denied, stop.
+7. **Wait for user confirmation.** If denied, stop.
 
-5. **Create `_codeguide/` directory** if it does not exist. If it already exists, leave existing files untouched — this step is the promote case.
+8. **Create `<root>/_codeguide/` directory** if it does not exist. If it already exists, leave existing files untouched — this step is the promote case.
 
-6. **Create `_codeguide/root.txt`** with the resolved path to the ancestor `_codeguide/`.
+9. **Create `<root>/_codeguide/root.txt`** with the resolved path to the ancestor `_codeguide/`.
 
-7. **Create `_codeguide/cgexclude.md`** from template — only if it does not already exist.
+10. **Create `<root>/_codeguide/cgexclude.md`** from template — only if it does not already exist.
 
-8. **Report** what was created (distinguish "created new subfolder workspace" vs "promoted existing `_codeguide/` to subfolder workspace", listing which files were touched).
+11. **Commit (sibling mode only):** `codeguide-setup: activate subfolder <rel-path>`.
+
+12. **Report** what was created (distinguish "created new subfolder workspace" vs "promoted existing `_codeguide/` to subfolder workspace").
 
 ## Rules
 
 - Do not overwrite user-owned files: config.yaml values, local-rules.md, cgexclude.md, Overview.md, module docs.
-- Do not commit. The user decides when to commit.
+- Inline mode: do not commit. Outer `@git-commit` stages and commits.
+- Sibling mode: commit each change in the sibling repo as its own commit; the target repo is never touched.
+- **Never modify the target repo in sibling mode.** Don't touch `.gitignore`, don't drop marker files, don't auto-create `.codeguide-root` — users who want that override file create it themselves.
 - Safe to re-run in any mode. Plugin-owned files are refreshed, user-owned files are preserved.

--- a/plugins/codeguide/skills/codeguide-setup/SKILL.md
+++ b/plugins/codeguide/skills/codeguide-setup/SKILL.md
@@ -21,7 +21,7 @@ _codeguide/
 
 ## Steps
 
-1. **Detect context:** Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/millpy/codeguide/resolve.py` to find the nearest `_codeguide/` with config.yaml.
+1. **Detect context:** Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/resolve.py` to find the nearest `_codeguide/` with config.yaml.
 
 2. **Determine mode:**
    - Config.yaml not found anywhere → **first-time root setup**

--- a/plugins/codeguide/skills/codeguide-update/SKILL.md
+++ b/plugins/codeguide/skills/codeguide-update/SKILL.md
@@ -4,46 +4,65 @@ description: "Update docs for recently changed source files. Default: current gi
 argument-hint: "[1h | 3d | HEAD~3 | file1 file2 ...]"
 ---
 
-Update `_codeguide/` docs for source files that changed recently. Designed to be fast and non-intrusive — only touches docs for files in scope. Does **not** commit.
+Update `_codeguide/` docs for source files that changed recently. Designed to be fast and non-intrusive — only touches docs for files in scope.
+
+Commit behavior is mode-aware:
+- **Inline mode** → `codeguide_commit.py` stages doc files in the current repo. The outer `@git-commit` skill that invoked us will commit them alongside the source changes.
+- **Sibling mode** → `codeguide_commit.py` stages AND commits doc files inside the sibling repo (its own history). The outer `@git-commit` must NOT try to stage sibling-rooted paths.
 
 ## Scope
 
 `$ARGUMENTS` controls which source files are in scope:
 
-- No argument → files in the current git diff (staged + unstaged). This is the default when called by mill-commit.
+- No argument → files in the current git diff (staged + unstaged). This is the default when called by `@git-commit`.
 - `1h`, `3d`, `2w` → files with git commits in the last hour / 3 days / 2 weeks
 - `HEAD~3` → files changed in the last 3 commits
 - Explicit file/folder paths → only those
 
 ## Steps
 
-1. **Find `_codeguide/`:** Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/resolve.py` to locate the nearest `_codeguide/` containing config.yaml. If not found, stop — codeguide is not initialized.
+1. **Resolve per file → group by cg-root.** For each source file in scope, run `python ${CLAUDE_PLUGIN_ROOT}/scripts/resolve.py --json` from that file's directory to get `{mode, cg_root, sibling_anchor}`. Group files whose resolve result shares the same `cg_root`. Files with `found == false` (no governing codeguide) → flag and skip.
 
-2. **Read config:** Load source extensions from `_codeguide/config.yaml`. Filter scope to recognized source files only.
+   Most repos have a single root codeguide, so typically you get one group. Multi-codeguide repos (repo-level + one-or-more subfolder workspaces) get one group per subtree.
 
-3. **Read cgignore.md and cgexclude.md:** Skip files matching ignore or exclude patterns.
+2. **For each group** — each group has its own `mode`, `cg_root`, and (for sibling) `sibling_anchor`:
 
-4. **Read the Documentation Guide:** Read `_codeguide/modules/DocumentationGuide.md`.
+   a. **Read config:** Load source extensions from `<cg_root>/config.yaml`. Filter the group's files to recognized source extensions only.
 
-5. **Read local rules:** Read `_codeguide/local-rules.md` if it exists.
+   b. **Read `cgignore.md` and `cgexclude.md`:** Skip files matching ignore or exclude patterns.
 
-6. **For each source file in scope:**
+   c. **Read the Documentation Guide:** `<cg_root>/modules/DocumentationGuide.md`.
 
-   a. Find the corresponding doc using the guide's naming rules (two-step lookup via Overview.md).
+   d. **Read local rules:** `<cg_root>/local-rules.md` if it exists.
 
-   b. **If doc exists:** Read the doc and the source file. If the doc is stale or inaccurate, update it. Preserve accurate content.
+   e. **For each source file in the group's filtered scope:**
 
-   c. **If no doc exists and not in cgexclude:** Create it following the guide structure. Update the project Overview.md module table.
+      - Find the corresponding doc using the guide's naming rules (two-step lookup via Overview.md).
+      - **If doc exists:** Read the doc and the source file. If the doc is stale or inaccurate, update it. Preserve accurate content.
+      - **If no doc exists and not in cgexclude:** Create it following the guide structure. Update the Overview.md module table.
+      - **If source was deleted** (only applies to git diff scope): Flag the orphan doc to the user. Do not delete it.
 
-   d. **If source was deleted** (only applies to git diff scope): Flag the orphan doc to the user. Do not delete it.
+   f. **Update Overview.md routing tables** if any docs were added or if routing hints changed.
 
-7. **Update Overview routing tables** if any docs were added or if routing hints changed.
+   g. **Stage / commit for this group:** Collect all absolute paths of docs that were created or updated for this group into a `--file` list. Run:
 
-8. **Report** what was updated, created, or flagged.
+      ```
+      python ${CLAUDE_PLUGIN_ROOT}/scripts/codeguide_commit.py \
+        --mode <group-mode> \
+        [--sibling-anchor <group-sibling-anchor>] \
+        --file <path> [--file <path> ...] \
+        -m "codeguide-update: <summary>"
+      ```
+
+      Pass the `mode` and (if sibling) `sibling-anchor` that resolve.py returned for THIS group. Never re-invoke `resolve.py` from the helper.
+
+3. **Report** per group: cg_root, mode, files updated/created/flagged. In sibling mode, report the sibling commit SHA for traceability.
 
 ## Rules
 
 - Read the Documentation Guide and local rules first — do not rely on memory.
 - Do not touch docs outside the scope.
 - Do not include API signatures, code-derived values, or line-by-line walkthroughs.
-- Do not commit. The caller (user or mill-commit) decides when to commit.
+- Inline mode: do NOT commit (the outer `@git-commit` does that). `codeguide_commit.py --mode inline` only stages.
+- Sibling mode: `codeguide_commit.py --mode sibling` stages + commits in the sibling repo. One commit per group.
+- Multi-codeguide: always process each cg-root's group with its own mode + anchor, never a mixed call.

--- a/plugins/codeguide/skills/codeguide-update/SKILL.md
+++ b/plugins/codeguide/skills/codeguide-update/SKILL.md
@@ -17,7 +17,7 @@ Update `_codeguide/` docs for source files that changed recently. Designed to be
 
 ## Steps
 
-1. **Find `_codeguide/`:** Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/millpy/codeguide/resolve.py` to locate the nearest `_codeguide/` containing config.yaml. If not found, stop — codeguide is not initialized.
+1. **Find `_codeguide/`:** Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/resolve.py` to locate the nearest `_codeguide/` containing config.yaml. If not found, stop — codeguide is not initialized.
 
 2. **Read config:** Load source extensions from `_codeguide/config.yaml`. Filter scope to recognized source files only.
 

--- a/plugins/mill/integration_tests/test-merge.py
+++ b/plugins/mill/integration_tests/test-merge.py
@@ -12,7 +12,7 @@ Layout mirrors `test-spawn.py`:
     <container>/wiki.git          bare "remote" for the wiki
     <container>/wiki              working clone of the bare
     <container>/hub               hub repo (the parent)
-    <container>/hub.worktrees/<slug>   child worktree under the task branch
+    <container>/worktrees/<slug>       child worktree under the task branch (hub-form default)
 
 Flow under test (mirrors mill-merge SKILL.md step numbering):
 
@@ -87,7 +87,7 @@ def _setup_trio(container: Path) -> tuple[Path, Path, Path, str]:
     bare = container / "wiki.git"
     wiki = container / "wiki"
     hub = container / "hub"
-    worktrees_dir = container / "hub.worktrees"
+    worktrees_dir = container / "worktrees"
     worktree = worktrees_dir / slug
 
     # Bare wiki + clone.
@@ -113,8 +113,7 @@ def _setup_trio(container: Path) -> tuple[Path, Path, Path, str]:
         "  .active: <WIKI_PATH>/active/<SLUG>/\n"
         "\n"
         "spawn:\n"
-        "  branch_prefix: test\n"
-        "  worktrees_dir: <CONTAINER_PATH>/<REPO>.worktrees\n",
+        "  branch_prefix: test\n",
         encoding="utf-8",
     )
     active_dir = wiki / "active" / slug

--- a/plugins/mill/integration_tests/test-spawn.py
+++ b/plugins/mill/integration_tests/test-spawn.py
@@ -5,7 +5,8 @@ Builds an isolated hub+wiki pair under ``.millhouse/scratch/`` and runs
 ``mill-spawn.py`` against it. Asserts the end-to-end artefacts:
 
     - Home.md heading for the seeded task switches to ``[active]``.
-    - A new worktree directory exists at ``<container>/hub.worktrees/<slug>``.
+    - A new worktree directory exists at ``<container>/worktrees/<slug>``
+      (hub-form default, via _sibling.resolve_path).
     - The task's branch exists with the expected name.
     - ``wiki/active/<slug>/status.md`` exists with the expected title.
     - ``<worktree>/.vscode/settings.json`` has a non-green colour.
@@ -63,7 +64,7 @@ def _setup_pair(container: Path) -> tuple[Path, Path, Path]:
     bare = container / "wiki.git"
     wiki = container / "wiki"
     hub = container / "hub"
-    worktrees_dir = container / "hub.worktrees"
+    worktrees_dir = container / "worktrees"
 
     # Bare wiki + clone. The bare acts as origin so mill-spawn's
     # sync_pull/write_commit_push paths exercise real push/pull.
@@ -89,8 +90,7 @@ def _setup_pair(container: Path) -> tuple[Path, Path, Path]:
         "  .active: <WIKI_PATH>/active/<SLUG>/\n"
         "\n"
         "spawn:\n"
-        "  branch_prefix: test\n"
-        "  worktrees_dir: <CONTAINER_PATH>/<REPO>.worktrees\n",
+        "  branch_prefix: test\n",
         encoding="utf-8",
     )
     _run(["git", "-C", str(wiki), "add", "."], cwd=container)
@@ -249,7 +249,7 @@ def main() -> int:
             # worktree bookkeeping stays consistent on repeated runs.
             try:
                 _run(
-                    ["git", "worktree", "remove", "--force", str(container / "hub.worktrees" / "demo-task")],
+                    ["git", "worktree", "remove", "--force", str(container / "worktrees" / "demo-task")],
                     cwd=container / "hub",
                     check=False,
                 )

--- a/plugins/mill/scripts/_sibling.py
+++ b/plugins/mill/scripts/_sibling.py
@@ -1,0 +1,72 @@
+"""
+Sibling-path resolver: maps a (role, repo_root) pair to the canonical
+location of an adjacent sibling directory or repo.
+
+Hub-form vs prefix-form
+-----------------------
+If ``repo_root.name == "hub"`` (exact, case-sensitive), the repo is in
+*hub-form*: siblings live as bare names next to it.
+
+    <container>/hub/
+    <container>/worktrees/
+    <container>/wiki/
+    <container>/codeguide/
+
+Otherwise (*prefix-form*) siblings carry the repo's name as a prefix so
+multiple repos can share the same parent directory without collision.
+
+    <container>/foo/
+    <container>/foo.worktrees/
+    <container>/foo.wiki/
+    <container>/foo.codeguide/
+
+Hub-form detection is deliberately literal — ``Hub/`` or ``HUB/`` fall
+through to prefix-form. Zero heuristics keeps the rule predictable.
+
+Identical-twin rule
+-------------------
+``plugins/codeguide/scripts/_sibling.py`` is a byte-for-byte copy of
+this module (modulo plugin-specific docstring). If you change one,
+grep for the other and apply the same change. Each plugin carries
+its own copy so neither imports across plugin boundaries (plugin
+install paths are not guaranteed to be relative siblings).
+
+Usage
+-----
+Python::
+
+    from _sibling import resolve_path
+    resolve_path("worktrees", Path("/c/Code/millhouse/hub"))
+    # -> Path("/c/Code/millhouse/worktrees")
+
+CLI (for SKILL.md prose / subprocess callers)::
+
+    python _sibling.py worktrees /c/Code/millhouse/hub
+    # prints: /c/Code/millhouse/worktrees
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def resolve_path(role: str, repo_root: Path) -> Path:
+    repo_root = Path(repo_root)
+    parent = repo_root.parent
+    if repo_root.name == "hub":
+        return parent / role
+    return parent / f"{repo_root.name}.{role}"
+
+
+def _main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print("usage: _sibling.py <role> <repo_root>", file=sys.stderr)
+        return 2
+    role = argv[1]
+    repo_root = Path(argv[2])
+    print(resolve_path(role, repo_root))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv))

--- a/plugins/mill/scripts/mill-spawn.py
+++ b/plugins/mill/scripts/mill-spawn.py
@@ -241,12 +241,20 @@ def _build_tokens(
     return tokens
 
 
-def _resolve_worktrees_dir(cfg: dict, tokens: dict[str, str]) -> Path:
-    """Return the worktrees-dir from ``spawn.worktrees_dir``, resolving tokens."""
-    template = cfg.get("spawn", {}).get(
-        "worktrees_dir", "<CONTAINER_PATH>/<REPO>.worktrees"
-    )
-    return Path(_junction.resolve_target(template, tokens))
+def _resolve_worktrees_dir(cfg: dict, tokens: dict[str, str], git_root: Path) -> Path:
+    """Return the worktrees-dir.
+
+    When ``cfg["spawn"]["worktrees_dir"]`` is set explicitly (user override),
+    treat it as a token template and substitute. When absent, delegate to
+    ``_sibling.resolve_path("worktrees", git_root)`` — this yields the
+    hub-form default (``<container>/worktrees/``) or the prefix-form default
+    (``<container>/<repo>.worktrees/``) per the unified sibling-path rule.
+    """
+    template = cfg.get("spawn", {}).get("worktrees_dir")
+    if template is not None:
+        return Path(_junction.resolve_target(template, tokens))
+    import _sibling  # lazy import to keep module-level imports stable
+    return _sibling.resolve_path("worktrees", git_root)
 
 
 # --------------------------------------------------------------------------- #
@@ -316,7 +324,7 @@ def main(argv: list[str] | None = None) -> int:
     branch_name = f"{branch_prefix}/{slug}" if branch_prefix else slug
 
     tokens = _build_tokens(git_root, wiki_path, slug=slug)
-    worktrees_dir = _resolve_worktrees_dir(cfg, tokens)
+    worktrees_dir = _resolve_worktrees_dir(cfg, tokens, git_root)
     worktree_path = worktrees_dir / slug
 
     if args.dry_run:

--- a/plugins/mill/skills/git-commit/SKILL.md
+++ b/plugins/mill/skills/git-commit/SKILL.md
@@ -14,9 +14,12 @@ Run these before staging. Both are conditional — skip if the condition isn't m
 
 Detect the project language (see `@mill:workflow` Language Detection) and run the lint step from the matching `{lang}-build` skill on changed files. Skip if no source files changed or no language detected.
 
-### 2. Codeguide sync (only if `_codeguide/` exists)
+### 2. Codeguide sync (only if codeguide is initialized)
 
-If `_codeguide/Overview.md` exists anywhere in the repo, run `@codeguide:codeguide-update` (no arguments — it defaults to the current git diff). Stage any updated or created doc files alongside source files.
+Run `@codeguide:codeguide-update` whenever codeguide is initialized for this repo — either **inline** (`_codeguide/Overview.md` exists under the repo) or **sibling** (a separate `<container>/<repo>.codeguide/` or `<container>/codeguide/` repo exists). `codeguide-update` resolves the mode itself via `resolve.py` and handles both.
+
+- **Inline mode** → doc files live inside this repo. `codeguide-update`'s helper (`codeguide_commit.py --mode inline`) stages them; this skill commits them alongside source changes as part of step 3.
+- **Sibling mode** → doc files live in the sibling repo and are committed there by `codeguide_commit.py --mode sibling` as its own commit. **Do not** try to stage sibling-rooted paths in this commit — the sibling has its own history.
 
 ## Rules
 

--- a/plugins/mill/skills/mill-setup/SKILL.md
+++ b/plugins/mill/skills/mill-setup/SKILL.md
@@ -22,13 +22,23 @@ Bootstrap the mill infrastructure from nothing. Produces a working `.millhouse/`
 
 ## Layout assumed
 
+Hub-form (cwd dir is named exactly `hub`):
+
 ```
 <container>/
   hub/            <- cwd
   wiki/           <- sibling, created or reused in Phase 3
 ```
 
-Every path below is relative to `cwd` unless noted. Use absolute paths when calling the Python helpers (resolve via `Path(...).resolve()`).
+Prefix-form (any other name, e.g. `foo`):
+
+```
+<container>/
+  foo/            <- cwd
+  foo.wiki/       <- sibling, created or reused in Phase 3
+```
+
+The form is decided by `_sibling.py wiki <HUB_PATH>` in Phase 3 — callers just use `<wiki-dir>` thereafter. Every path below is relative to `cwd` unless noted. Use absolute paths when calling the Python helpers (resolve via `Path(...).resolve()`).
 
 ## How to invoke the helpers
 
@@ -61,19 +71,27 @@ Run `git ls-remote <wiki-url>`. If it fails (exit non-zero), halt with:
 >
 > (GitHub does not create the wiki git repo until the first page is saved.)
 
-### Phase 3 — Clone or fast-forward the wiki at `<container>/wiki`
+### Phase 3 — Clone or fast-forward the wiki at `<wiki-dir>`
 
-1. If `<container>/wiki/` does not exist: `git clone <wiki-url> <container>/wiki`.
-2. If `<container>/wiki/` exists and is a git repo (`<container>/wiki/.git/` present): `git -C <container>/wiki pull --ff-only`.
-3. If `<container>/wiki/` exists but is not a git repo: halt with:
-   > `<container>/wiki/` exists but is not a git repository. Move it aside or remove it, then re-run `/mill-setup`. mill-setup never overwrites user data.
+First compute `<wiki-dir>` using the sibling-path helper — this yields `<container>/wiki/` when the hub directory is named exactly `hub`, otherwise `<container>/<repo>.wiki/`. Use the printed path as `<wiki-dir>` for the remainder of mill-setup (Phases 3, 3.5, 4, 6, 6a, 8):
+
+```powershell
+python "${env:CLAUDE_PLUGIN_ROOT}/scripts/_sibling.py" wiki "<hub-path>"
+```
+
+`<hub-path>` is `<HUB_PATH>` from Phase 3.5 (`git rev-parse --show-toplevel`). Users can override via `.millhouse/config.local.yaml`'s `wiki_path:` key — that value wins over the helper's default.
+
+1. If `<wiki-dir>` does not exist: `git clone <wiki-url> <wiki-dir>`.
+2. If `<wiki-dir>` exists and is a git repo (`<wiki-dir>/.git/` present): `git -C <wiki-dir> pull --ff-only`.
+3. If `<wiki-dir>` exists but is not a git repo: halt with:
+   > `<wiki-dir>` exists but is not a git repository. Move it aside or remove it, then re-run `/mill-setup`. mill-setup never overwrites user data.
 
 ### Phase 3.5 — Resolve junctions from wiki config
 
-After the wiki is cloned (Phase 3) but before any junction is created, read the `junctions:` block from `<container>/wiki/config.yaml`:
+After the wiki is cloned (Phase 3) but before any junction is created, read the `junctions:` block from `<wiki-dir>/config.yaml`:
 
 ```powershell
-python -c "from pathlib import Path; import _wiki; import json; print(json.dumps(_wiki.read_junctions(Path(r'<container>/wiki').resolve())))"
+python -c "from pathlib import Path; import _wiki; import json; print(json.dumps(_wiki.read_junctions(Path(r'<wiki-dir>').resolve())))"
 ```
 
 `read_junctions` returns a dict of `{junction-path: target-template}`. Defaults when the config file or `junctions:` block is absent:
@@ -86,7 +104,7 @@ python -c "from pathlib import Path; import _wiki; import json; print(json.dumps
 - `<HUB_PATH>` — the primary clone. Derive via `git rev-parse --show-toplevel` (and, in future, worktree-detect to fall back to the primary from a worktree subfolder).
 - `<CWD_PATH>` — current working directory (absolute).
 - `<CONTAINER_PATH>` — parent of `<HUB_PATH>` (holds hub/, wiki/, worktrees/).
-- `<WIKI_PATH>` — the wiki clone. Default: `<CONTAINER_PATH>/<REPO>.wiki/`. Override if `.millhouse/config.local.yaml` has a `wiki_path:` key (future).
+- `<WIKI_PATH>` — the wiki clone (`<wiki-dir>` from Phase 3). Default: computed by `python ${CLAUDE_PLUGIN_ROOT}/scripts/_sibling.py wiki <HUB_PATH>` — hub-form yields `<CONTAINER_PATH>/wiki/`, prefix-form yields `<CONTAINER_PATH>/<REPO>.wiki/`. Override if `.millhouse/config.local.yaml` has a `wiki_path:` key.
 - `<REPO>` — short repo name from origin URL (last path segment, stripped of `.git`).
 
 Do **NOT** add `<SLUG>` — mill-setup only handles hub-scope junctions. Entries whose template contains `<SLUG>` belong to mill-spawn.
@@ -130,7 +148,7 @@ Iterate until all hub junctions are present. Entries with `<SLUG>` are left to m
 
 ### Phase 6 — Initialise or normalise `Home.md`
 
-Decide what to do based on the current content of `<container>/wiki/Home.md`:
+Decide what to do based on the current content of `<wiki-dir>/Home.md`:
 
 | Current state | Action |
 |---|---|
@@ -141,11 +159,11 @@ Decide what to do based on the current content of `<container>/wiki/Home.md`:
 
 For "missing" and "GitHub default" cases:
 
-1. Copy `plugins/mill/templates/Home.md` → `<container>/wiki/Home.md` verbatim.
+1. Copy `plugins/mill/templates/Home.md` → `<wiki-dir>/Home.md` verbatim.
 2. Commit and push via `_wiki.write_commit_push`:
 
    ```powershell
-   python -c "from pathlib import Path; import _wiki; _wiki.write_commit_push(Path(r'<container>/wiki').resolve(), ['Home.md'], '<commit-msg>')"
+   python -c "from pathlib import Path; import _wiki; _wiki.write_commit_push(Path(r'<wiki-dir>').resolve(), ['Home.md'], '<commit-msg>')"
    ```
 
    (Use the commit message from the table above.)
@@ -159,17 +177,17 @@ The wiki sidebar is auto-generated from `Home.md` and the set of `proposal-*.md`
 Run:
 
 ```powershell
-python -c "from pathlib import Path; import _sidebar; _sidebar.regenerate(Path(r'<container>/wiki').resolve())"
+python -c "from pathlib import Path; import _sidebar; _sidebar.regenerate(Path(r'<wiki-dir>').resolve())"
 ```
 
 Then commit + push if the file changed:
 
-1. Check `git -C <container>/wiki status --porcelain _Sidebar.md`.
+1. Check `git -C <wiki-dir> status --porcelain _Sidebar.md`.
 2. If the command prints nothing, the sidebar is already correct — skip the commit. (Idempotency: second and later runs land here.)
 3. Otherwise, commit via `_wiki.write_commit_push`:
 
    ```powershell
-   python -c "from pathlib import Path; import _wiki; _wiki.write_commit_push(Path(r'<container>/wiki').resolve(), ['_Sidebar.md'], 'chore: regenerate _Sidebar.md')"
+   python -c "from pathlib import Path; import _wiki; _wiki.write_commit_push(Path(r'<wiki-dir>').resolve(), ['_Sidebar.md'], 'chore: regenerate _Sidebar.md')"
    ```
 
 **Why separate from Phase 6:** Phase 6 only writes `Home.md` on the missing / GitHub-default branches. When Phase 6 skips (Home.md already in v2 shape), the sidebar still needs to be regenerated the first time `mill-setup` runs against a clone that was bootstrapped before this phase existed. Running it unconditionally is cheap and keeps the two commits separate in history: one says "init Home.md", the other says "regenerate _Sidebar.md".
@@ -239,7 +257,7 @@ Next: /mill-add <slug> --title "..." [--summary "..."] [--proposal-body "..."] t
 | Condition | Action |
 |---|---|
 | `git ls-remote <wiki-url>` fails | Halt with GitHub URL + instruction to create Home page |
-| `<container>/wiki/` exists but not a git repo | Halt — never overwrite user data |
+| `<wiki-dir>` exists but not a git repo | Halt — never overwrite user data |
 | `.millhouse/wiki` junction points elsewhere | Halt with remove-and-rerun instruction |
 | Push of `Home.md` fails (network / auth) | Halt; user fixes network and re-runs |
 | A Python helper raises | Show the traceback from the Python invocation and halt |

--- a/plugins/mill/unit_tests/test-sibling.py
+++ b/plugins/mill/unit_tests/test-sibling.py
@@ -1,0 +1,76 @@
+"""Unit tests for plugins/mill/scripts/_sibling.py."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+HUB = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPTS_DIR = HUB / "plugins" / "mill" / "scripts"
+SIBLING_PY = SCRIPTS_DIR / "_sibling.py"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from _sibling import resolve_path  # noqa: E402
+
+
+def _check(role: str, repo_root: str, expected: str) -> None:
+    got = resolve_path(role, Path(repo_root))
+    assert got == Path(expected), f"resolve_path({role!r}, {repo_root!r}) -> {got}, expected {expected}"
+
+
+def main() -> int:
+    try:
+        _check("worktrees", "/c/Code/millhouse/hub", "/c/Code/millhouse/worktrees")
+        _check("wiki", "/c/Code/millhouse/hub", "/c/Code/millhouse/wiki")
+        _check("codeguide", "/c/Code/millhouse/hub", "/c/Code/millhouse/codeguide")
+        print("PASS: hub-form -> bare role next to hub/")
+
+        _check("worktrees", "/c/projects/foo", "/c/projects/foo.worktrees")
+        _check("wiki", "/c/projects/foo", "/c/projects/foo.wiki")
+        _check("codeguide", "/c/projects/foo", "/c/projects/foo.codeguide")
+        print("PASS: prefix-form -> <name>.<role> next to repo")
+
+        _check("worktrees", "/c/x/Hub", "/c/x/Hub.worktrees")
+        _check("worktrees", "/c/x/HUB", "/c/x/HUB.worktrees")
+        _check("worktrees", "/c/x/hub-v2", "/c/x/hub-v2.worktrees")
+        _check("worktrees", "/c/x/my-hub", "/c/x/my-hub.worktrees")
+        print("PASS: hub-form match is case-sensitive and literal")
+
+        _check("codeguide", "/tmp/hub", "/tmp/codeguide")
+        _check("codeguide", "/tmp/hub/", "/tmp/codeguide")
+        print("PASS: trailing slash on repo_root does not break detection")
+
+        cli_cases = [
+            ("worktrees", "/c/Code/millhouse/hub", "/c/Code/millhouse/worktrees"),
+            ("wiki", "/c/projects/foo", "/c/projects/foo.wiki"),
+            ("codeguide", "/c/x/Hub", "/c/x/Hub.codeguide"),
+        ]
+        for role, repo_root, expected in cli_cases:
+            result = subprocess.run(
+                [sys.executable, str(SIBLING_PY), role, repo_root],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0, f"CLI exit={result.returncode} stderr={result.stderr}"
+            out = result.stdout.strip()
+            assert Path(out) == Path(expected), f"CLI({role}, {repo_root}) -> {out!r}, expected {expected!r}"
+        print("PASS: CLI entry point prints resolved path, exit 0")
+
+        bad = subprocess.run(
+            [sys.executable, str(SIBLING_PY), "only-one-arg"],
+            capture_output=True,
+            text=True,
+        )
+        assert bad.returncode == 2, f"expected exit 2 for bad args, got {bad.returncode}"
+        assert "usage" in bad.stderr.lower()
+        print("PASS: CLI exits 2 with usage message on bad args")
+
+        print("All _sibling unit tests passed.")
+        return 0
+    except AssertionError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/component/00-codeguide-sibling-mode.md
+++ b/specs/component/00-codeguide-sibling-mode.md
@@ -1,15 +1,21 @@
-# codeguide sibling-mode — docs outside the target repo
+# codeguide sibling-mode + unified sibling-path convention
 
 ```yaml
-type: plugin change (codeguide) + CLAUDE.md convention
+type: plugin change (codeguide) + _sibling.py helper + mill-config unification
 layer: bookkeeping / external tooling
 v1_ref: none — new capability
-status: partially discussed — key decisions captured, not ready for full-write
-note: "Let `_codeguide/` live in a sibling git repo (`<repo-parent>/<repo>.codeguide/`) instead of inside the target repo. Zero-footprint mode for repos where docs should not pollute the source tree. Wiki stays unaffected (already sibling). Mill-v2 unaffected at the skill-contract level — only the codeguide plugin changes."
+status: discussed — ready for plan-writing
+note: "Let `_codeguide/` live in a sibling git repo next to the target repo. Same hub-form detection rule (`repo/.name == 'hub'`) unifies the naming convention across wiki, worktrees, and codeguide. Zero-footprint inside the target repo. Mill-v2 skill-contracts unaffected."
 priority: run before specs 07+. Triggered by the engineer's upcoming work on a third-party codebase where `_codeguide/` files cannot live in the main repo.
 ```
 
-**For the thread that will do the full-write:** these notes are *starting points*, not a finished spec. Grill Henrik further on the Open design points before writing plan or code. Treat the existing `plugins/codeguide/` plugin as the primary reference — most of this spec modifies it rather than adding new surface. The Millhouse hub itself (this repo) is not seeded with `_codeguide/` during this work; per project convention we wait until mill-v2 can drive that seed through its own workflow.
+## Scope summary (post-discussion)
+
+Three logical pieces, all shipped together:
+
+1. **`_sibling.py` helper in mill plugin** — single source of truth for where sibling dirs live (wiki, codeguide, worktrees). Hub-form detection: if the repo directory is literally named `hub`, use role-only paths (`<parent>/codeguide/`); otherwise prefix with repo dir name (`<parent>/<repo-name>.codeguide/`).
+2. **Codeguide plugin gains sibling mode** — `_codeguide/` can live outside the target repo as its own git repo. Inline mode (current behaviour) stays as default. Resolution chain: inline first → `.codeguide-root` file override → sibling via hub-form rule → fail.
+3. **Mill-setup and mill-spawn use `_sibling.py`** — removes the `spawn.worktrees_dir` token-template config default and the documented `<WIKI_PATH>` default, replacing both with the unified helper. Explicit overrides in `.millhouse/config.local.yaml` continue to work.
 
 ## Problem
 
@@ -20,26 +26,86 @@ priority: run before specs 07+. Triggered by the engineer's upcoming work on a t
 
 Sibling layout — `<parent>/<repo>.codeguide/` as its own git repo — sidesteps both: zero files in the target repo, full version control on the docs, consistent with Millhouse's existing wiki pattern (`<parent>/<repo>.wiki/`).
 
-## Decisions
+## Decisions (finalized)
 
-- **Two modes, user-chosen at setup time:**
-  - **Inline** (current default): `<repo>/_codeguide/` inside the target repo. Committed with source via `git-commit` skill.
-  - **Sibling**: `<repo-parent>/<repo>.codeguide/` as its own git repo. Committed independently.
-- **Location resolution — `resolve.py` walks up from cwd:**
-  - For each level between cwd and git-toplevel (inclusive):
-    - Try inline: `<level>/_codeguide/Overview.md`.
-    - Try sibling-mirror: `<git-parent>/<repo>.codeguide/<rel-path>/_codeguide/Overview.md` where `<rel-path>` is the path from git-toplevel to `<level>`.
-  - First match wins.
-  - Env var `CODEGUIDE_ROOT`, when set, replaces `<git-parent>/<repo>.codeguide/` with its value. Rare — only for oddball layouts where sibling convention cannot apply.
-  - No match at any level → "run /codeguide-setup first".
-- **Multi-codeguide support:** the mirror scheme handles it naturally — if `src/csharp/NORCE.Models/` runs setup with `--sibling`, its codeguide lives at `<sibling>/src/csharp/NORCE.Models/_codeguide/`. A second subfolder gets its own `_codeguide/` at the mirrored path. First-to-setup triggers `git init` on the sibling repo; later setups just `mkdir` + commit inside it.
-- **Subfolder-init respects git-toplevel:** every path computation in `codeguide-setup` and `resolve.py` anchors on `git rev-parse --show-toplevel`, not on cwd. Running `/codeguide-setup --sibling` from `Models/src/csharp/NORCE.Models/` places the codeguide at `Models.codeguide/src/csharp/NORCE.Models/_codeguide/`, not at `src/csharp/NORCE.Models.codeguide/`.
-- **Sibling is always its own git repo.** `codeguide-setup` handles `git init` automatically on first use (analogous to how `mill-setup` handles the wiki clone). Optional `--from-url <git-url>` clones an existing remote instead.
-- **Monorepo-branch pattern is NOT a dedicated mode.** Users who want "one GitHub repo, many codeguides as branches, worktree-checkout per active one" handle the git plumbing themselves and pass `--sibling <path>` to setup. Keeps the plugin scope small; the worktree-per-branch pattern is a user-level choice, not a plugin responsibility.
-- **Commit discipline splits by mode:**
-  - **Inline:** unchanged. `git-commit` step 2 stages codeguide files alongside source.
-  - **Sibling:** `codeguide-update` calls a new helper (`${CLAUDE_PLUGIN_ROOT}/scripts/millpy/codeguide/codeguide_commit.py`) that does `git -C <sibling> add … && git -C <sibling> commit -m "…"` rooted in the sibling repo. `git-commit` step 2 still invokes `codeguide-update` but does not try to stage its output — the helper already committed in the other repo.
-- **Never assume the millhouse source repo is cloned.** All plugin scripts reference `${CLAUDE_PLUGIN_ROOT}` for their own files. A session running on a third-party repo with `codeguide` installed must work with nothing on disk but the plugin install + the target repo + the sibling repo (if in sibling mode).
+### Hub-form detection rule — single string check
+
+```python
+def is_hub_form(repo_root: Path) -> bool:
+    return repo_root.name == "hub"
+```
+
+The repo directory name is the entire signal. No heuristic on sibling presence, no config flag, no setup-time question. Existing Millhouse layout (`<container>/hub/`) triggers hub-form automatically; every other repo triggers prefix-form.
+
+### `_sibling.resolve_path(role, repo_root)` — one helper for all siblings
+
+```python
+def resolve_path(role: str, repo_root: Path) -> Path:
+    parent = repo_root.parent
+    if repo_root.name == "hub":
+        return parent / role
+    return parent / f"{repo_root.name}.{role}"
+```
+
+Applied uniformly to `role` in `{"wiki", "codeguide", "worktrees"}`. Lives at `plugins/mill/scripts/_sibling.py`. Consumed by `mill-spawn`, `mill-setup`, and (via subprocess call from the codeguide plugin) the codeguide `resolve.py`.
+
+### Codeguide — two modes, chosen at setup time
+
+- **Inline** (default): `<repo>/_codeguide/` inside the target repo. Committed with source via `@git-commit` skill's pre-commit step 2. Current behaviour, unchanged.
+- **Sibling**: `_sibling.resolve_path("codeguide", repo_root)` as its own git repo. Committed independently by `codeguide_commit.py` helper. Never touches the target repo.
+
+`codeguide-setup --sibling [--from-url <git-url>]` creates the sibling repo on first use (`git init` locally, or clone from URL). Subsequent setups in subfolders `mkdir` + commit into the existing sibling repo.
+
+### Resolve chain (codeguide, walked from cwd up to git-toplevel)
+
+1. For each level between cwd and git-toplevel (inclusive):
+   - Inline: does `<level>/_codeguide/Overview.md` exist?
+2. If no inline match: is there a `.codeguide-root` file at git-toplevel? If yes, read the path inside it.
+3. If no override file: compute `sibling_root = _sibling.resolve_path("codeguide", git_toplevel)`.
+4. For each level (same sweep): does `<sibling_root>/<rel-path>/_codeguide/Overview.md` exist? (`<rel-path>` is the path from git-toplevel to `<level>`.)
+5. First match wins. No match at any step → "run /codeguide-setup first".
+
+### `.codeguide-root` override file
+
+- Path: `<git-toplevel>/.codeguide-root`. Single line containing an absolute or relative path (relative to git-toplevel).
+- Purpose: point at an existing codeguide directory in a non-conventional location (monorepo-branch worktree, shared drive, etc.).
+- The plugin does NOT add this file to the target repo's `.gitignore`. The user is responsible for ignoring it (e.g., via `~/.gitignore_global`). "Zero-footprint" means we never modify the target repo — not even its gitignore.
+- `CODEGUIDE_ROOT` env var is NOT supported. `.codeguide-root` is the single override mechanism.
+
+### Multi-codeguide — sibling mirrors the subfolder structure
+
+When subfolders of the repo each have their own codeguide:
+- `<repo>/src/csharp/NORCE.Models/` runs setup → `<sibling>/src/csharp/NORCE.Models/_codeguide/`.
+- `<repo>/src/csharp/NORCE.Drilling/` runs setup → `<sibling>/src/csharp/NORCE.Drilling/_codeguide/`.
+
+The sibling repo only contains paths where codeguides actually exist; empty mirror directories are not created. A codeguide at the repo root, if the user sets one up there, lives at `<sibling>/_codeguide/`.
+
+Multi-codeguide also implies **grouping by codeguide-root**: `codeguide-update` parses the staged diff, calls `resolve.py` per file to find that file's governing codeguide-root, groups files by root, updates each group independently. `resolve.py` finds roots (deterministic); the DocumentationGuide rules inside each root govern which specific `.md` doc files change (non-deterministic — CC decides based on the routing rules).
+
+### Subfolder-init anchors on git-toplevel
+
+All path computation uses `git rev-parse --show-toplevel`, not cwd. Running `/codeguide-setup --sibling` from `Models/src/csharp/NORCE.Models/` places the codeguide at `Models.codeguide/src/csharp/NORCE.Models/_codeguide/`, not at `src/csharp/NORCE.Models.codeguide/` or similar cwd-anchored guess.
+
+### Commit discipline splits by mode
+
+- **Inline:** `git-commit` skill stages `_codeguide/` files alongside source in the same target-repo commit. Current behaviour.
+- **Sibling:** `codeguide-update` calls `${CLAUDE_PLUGIN_ROOT}/scripts/millpy/codeguide/codeguide_commit.py`. The helper does `git -C <sibling> add … && git -C <sibling> commit -m "…"` inside the sibling repo. `git-commit`'s step 2 still invokes `codeguide-update` but does not try to stage its output — the sibling commit is already done. Cadence stays per-commit.
+- Recovery path when the user bypasses `@git-commit`: `codeguide-maintain` skill (already in the plugin) sweeps a commit range and fixes drift. Documentation pointer included in the spec, no new tooling required.
+
+### Mill-v2 integration — shared helper, removed token defaults
+
+- `mill-spawn` switches from reading `cfg["spawn"]["worktrees_dir"]` as a token template to calling `_sibling.resolve_path("worktrees", repo_root)` when the key is absent. Explicit `spawn.worktrees_dir` set in `.millhouse/config.local.yaml` continues to override.
+- `mill-setup` switches from the documented `<CONTAINER_PATH>/<REPO>.wiki/` default to `_sibling.resolve_path("wiki", repo_root)`. Explicit `wiki_path:` in `.millhouse/config.local.yaml` continues to override.
+- `wiki/config.yaml` drops the `spawn.worktrees_dir` default and the `<WIKI_PATH>` documented default from its header comments. Override-only keys remain documented.
+- Integration test fixtures (`test-spawn.py`, `test-merge.py`) update to the new layout: test hub is at `<container>/hub/` → worktrees at `<container>/worktrees/` (not `<container>/hub.worktrees/`).
+
+### Monorepo-branch pattern — user-managed, not a plugin mode
+
+Users who want "one GitHub repo with many codeguides as branches, worktree-checkout per active one" set up the clone + branch-worktree themselves and point `.codeguide-root` at the chosen worktree directory. The plugin does not orchestrate this. Keeps plugin scope small; the pattern is a user-level choice.
+
+### Never assume the millhouse source repo is cloned
+
+All plugin scripts reference `${CLAUDE_PLUGIN_ROOT}` for their own files. A session running on a third-party repo with codeguide and mill plugins installed must work with nothing on disk but the plugin install + the target repo + the sibling repo (when in sibling mode). Rule enshrined in `CLAUDE.md` in this same spec's commit.
 
 ## Flow — sibling setup first-time
 
@@ -84,16 +150,25 @@ Sibling layout — `<parent>/<repo>.codeguide/` as its own git repo — sidestep
 - No automatic migration from inline → sibling. A user who decides to switch after the fact moves the files manually and re-runs setup with `--sibling`.
 - No CC-driven auto-seed of the hub (Millhouse) repo's own codeguide. That is spec `13-mill-codeguide.md` and remains deferred until mill-v2 self-sufficiency.
 
-## Open design points
+## Open design points (resolved during grilling)
 
-- **Mode persistence:** when `resolve.py` discovers a sibling, should it cache the result (e.g. in `<git-toplevel>/.git/info/codeguide-mode`) so subsequent skill invocations skip the walk? Probably yes for perf, but cache invalidation rules need specifying.
-- **`codeguide-update` on a multi-codeguide repo:** if a source-commit touches files under two subfolders that each have their own codeguide, the skill must update both. Scope currently says "scan the staged diff" — confirm resolve.py handles the diff-file-to-codeguide mapping gracefully.
-- **`codeguide-setup` refresh on an existing sibling:** what does `/codeguide-setup` do when invoked from a subfolder that already has a sibling-mirrored `_codeguide/`? "Root refresh" in current SKILL.md assumes inline. Sibling refresh needs equivalent semantics (overwrite plugin-owned files, keep user-owned).
-- **`.gitignore` for the target repo:** should sibling-mode setup *optionally* add `/_codeguide/` to the target repo's `.gitignore` as a safety net against stray inline files? Probably yes, guarded by a flag to avoid surprise diffs.
-- **`CODEGUIDE_ROOT` env var:** exact semantics. Override sibling-root only, or entire resolve chain? Lean toward "overrides sibling-root path", resolve chain otherwise unchanged.
-- **Subfolder that previously used `root.txt` pointer in sibling mode:** spec says cg-workspaces still work. Confirm the subfolder activation flow in sibling mode creates the pointer correctly.
-- **Verify + lint interactions:** `git-commit` step 1 is lint. When codeguide is sibling, does lint run in the target repo only, or also touch the sibling? (Likely target only — lint is about source code, not docs.)
-- **Spec 13 (`mill-codeguide` placeholder) reference:** should be updated after this spec lands so it points to "sibling or inline" rather than assuming inline. Minor edit.
+Kept for audit trail.
+
+- **Mode cache under `.git/info/`** — rejected. No cache; `resolve.py` walks fresh every call. Walk cost is microseconds; LLM calls dominate.
+- **Multi-codeguide per staged commit** — confirmed: `resolve.py` finds cg-ROOT per file (deterministic), `codeguide-update` groups files by root and updates each root independently.
+- **Sibling refresh semantics** — same as root refresh: overwrite plugin-owned files, preserve user-owned. Just applied at the sibling-mirror anchor.
+- **`.gitignore` safety-net in target repo** — rejected. Zero-footprint in target repo means we NEVER modify it, not even gitignore. User handles their own gitignore via `~/.gitignore_global` if needed.
+- **`CODEGUIDE_ROOT` env var** — rejected. `.codeguide-root` file at git-toplevel is the single override mechanism.
+- **`root.txt` workspaces in sibling mode** — same pattern as inline, just living at mirrored paths inside the sibling repo. No re-design.
+- **Lint scope** — `git-commit` step 1 lints source in the target repo only. Sibling is docs; markdown-skill conventions apply at EDIT time (inside `codeguide-update`), not at commit-lint time.
+- **Spec 13 reference** — one-line edit included in this implementation's final batch.
+
+## Out of scope vs. current codeguide plugin
+
+- No GUI / interactive branch-picker when `--from-url` points at a monorepo with many branches. User passes `<url>#<branch>` or separate `--branch` flag; implementation detail.
+- No automatic migration from inline → sibling. A user who decides to switch after the fact moves files manually and re-runs setup with `--sibling`.
+- No CC-driven auto-seed of the hub (Millhouse) repo's own codeguide. That is spec `13-mill-codeguide.md` and remains deferred until mill-v2 self-sufficiency.
+- Wiki stays config-override-able via `.millhouse/config.local.yaml` → `wiki_path:` — overriding the new `_sibling` default when present.
 
 ## References
 

--- a/specs/component/00-codeguide-sibling-mode.md
+++ b/specs/component/00-codeguide-sibling-mode.md
@@ -37,7 +37,7 @@ def is_hub_form(repo_root: Path) -> bool:
 
 The repo directory name is the entire signal. No heuristic on sibling presence, no config flag, no setup-time question. Existing Millhouse layout (`<container>/hub/`) triggers hub-form automatically; every other repo triggers prefix-form.
 
-### `_sibling.resolve_path(role, repo_root)` — one helper for all siblings
+### `_sibling.resolve_path(role, repo_root)` — one helper; two identical copies
 
 ```python
 def resolve_path(role: str, repo_root: Path) -> Path:
@@ -47,7 +47,14 @@ def resolve_path(role: str, repo_root: Path) -> Path:
     return parent / f"{repo_root.name}.{role}"
 ```
 
-Applied uniformly to `role` in `{"wiki", "codeguide", "worktrees"}`. Lives at `plugins/mill/scripts/_sibling.py`. Consumed by `mill-spawn`, `mill-setup`, and (via subprocess call from the codeguide plugin) the codeguide `resolve.py`.
+Applied uniformly to `role` in `{"wiki", "codeguide", "worktrees"}`.
+
+**Two independent copies** — one per plugin — deliberately NO cross-plugin import:
+
+- `plugins/mill/scripts/_sibling.py` — used by mill-spawn and by the mill-setup skill's subprocess calls. Exposes a CLI mode so the skill's prose can run `python ${CLAUDE_PLUGIN_ROOT}/scripts/_sibling.py <role> <repo_root>` to fetch the computed path.
+- `plugins/codeguide/scripts/_sibling.py` — used by codeguide's own `resolve.py` and `codeguide_commit.py`. Identical 3-line logic.
+
+Rationale: three lines of pure arithmetic. Duplicating across plugins avoids any assumption that mill and codeguide plugins install in a specific relative layout (which `${CLAUDE_PLUGIN_ROOT}/../mill/` would require). Plugin independence is the load-bearing property; minor duplication is the acceptable cost. If the rule ever changes, both files get the same edit — a linter check or a pre-merge grep can catch divergence.
 
 ### Codeguide — two modes, chosen at setup time
 
@@ -94,10 +101,16 @@ All path computation uses `git rev-parse --show-toplevel`, not cwd. Running `/co
 
 ### Mill-v2 integration — shared helper, removed token defaults
 
-- `mill-spawn` switches from reading `cfg["spawn"]["worktrees_dir"]` as a token template to calling `_sibling.resolve_path("worktrees", repo_root)` when the key is absent. Explicit `spawn.worktrees_dir` set in `.millhouse/config.local.yaml` continues to override.
-- `mill-setup` switches from the documented `<CONTAINER_PATH>/<REPO>.wiki/` default to `_sibling.resolve_path("wiki", repo_root)`. Explicit `wiki_path:` in `.millhouse/config.local.yaml` continues to override.
+- `mill-spawn.py` switches from reading `cfg["spawn"]["worktrees_dir"]` as a token template to calling `_sibling.resolve_path("worktrees", repo_root)` when the key is absent. Explicit `spawn.worktrees_dir` set in `.millhouse/config.local.yaml` continues to override.
+- `mill-setup` is a **skill** (`plugins/mill/skills/mill-setup/SKILL.md`), not a Python script. Its SKILL.md prose currently contains two internally-inconsistent defaults: Phase 3 clones the wiki at literal `<container>/wiki/` (hub-form), while Phase 3.5 declares the `<WIKI_PATH>` token default as `<CONTAINER_PATH>/<REPO>.wiki/` (prefix-form). The plan reconciles both to `_sibling.resolve_path("wiki", repo_root)` by updating the skill's prose to invoke `python ${CLAUDE_PLUGIN_ROOT}/scripts/_sibling.py wiki <hub-path>` as a subprocess call and using the printed result for both Phase 3 and Phase 3.5. Explicit `wiki_path:` in `.millhouse/config.local.yaml` continues to override.
 - `wiki/config.yaml` drops the `spawn.worktrees_dir` default and the `<WIKI_PATH>` documented default from its header comments. Override-only keys remain documented.
 - Integration test fixtures (`test-spawn.py`, `test-merge.py`) update to the new layout: test hub is at `<container>/hub/` → worktrees at `<container>/worktrees/` (not `<container>/hub.worktrees/`).
+
+### Pre-existing bug in codeguide plugin — fix before the sibling work
+
+The codeguide skills (`codeguide-setup`, `codeguide-update`, `codeguide-generate`, `codeguide-maintain`) all reference `${CLAUDE_PLUGIN_ROOT}/scripts/millpy/codeguide/resolve.py` — a stale path from the v1 `millpy`-package layout. The file actually lives at `${CLAUDE_PLUGIN_ROOT}/scripts/resolve.py`. Any invocation of those skills on a real install would fail at the first `python` call.
+
+This spec fixes all four SKILL.md files to reference the correct flat path BEFORE touching the resolver code. Scope creep is acceptable because the sibling-mode work compounds the issue (adding `codeguide_commit.py` at the stale path). Fix the path first, then extend.
 
 ### Monorepo-branch pattern — user-managed, not a plugin mode
 

--- a/specs/component/00-plan/00-overview.md
+++ b/specs/component/00-plan/00-overview.md
@@ -101,5 +101,5 @@ Modified files:
 - `plugins/mill/skills/mill-setup/SKILL.md`
 - `plugins/mill/integration_tests/test-spawn.py`
 - `plugins/mill/integration_tests/test-merge.py`
-- `wiki/config.yaml` (drops `spawn.worktrees_dir` default; updates `<WIKI_PATH>` header-comment)
+- `wiki/config.yaml` — lives in the wiki-sibling clone at `<container>/wiki/config.yaml`, accessible from hub root as `.millhouse/wiki/config.yaml` via the junction. Drops `spawn.worktrees_dir` default; updates `<WIKI_PATH>` header-comment.
 - `specs/component/13-mill-codeguide.md` (one-line edit: "inline or sibling")

--- a/specs/component/00-plan/00-overview.md
+++ b/specs/component/00-plan/00-overview.md
@@ -1,0 +1,90 @@
+# Plan: codeguide sibling-mode + unified sibling-path convention
+
+```yaml
+task: codeguide sibling-mode + unified sibling-path convention
+slug: 00-codeguide-sibling-mode
+approved: false
+started: 20260423-085500
+parent: main
+root: ""
+verify: python plugins/mill/unit_tests/run-all.py && python plugins/mill/integration_tests/test-spawn.py && python plugins/mill/integration_tests/test-merge.py && python plugins/mill/integration_tests/test-plan-assets.py && python plugins/mill/integration_tests/test-go-assets.py
+```
+
+## Batch Index
+
+```yaml
+batches:
+  - name: foundation
+    file: 01-foundation.md
+    depends-on: []
+    verify: python plugins/mill/unit_tests/test-sibling.py
+  - name: codeguide-plugin
+    file: 02-codeguide-plugin.md
+    depends-on: [foundation]
+    verify: null
+  - name: mill-integration
+    file: 03-mill-integration.md
+    depends-on: [foundation]
+    verify: python plugins/mill/integration_tests/test-spawn.py && python plugins/mill/integration_tests/test-merge.py
+  - name: docs
+    file: 04-docs.md
+    depends-on: [mill-integration, codeguide-plugin]
+    verify: null
+```
+
+## Shared Decisions
+
+### Decision: Hub-form detection is a single string check
+
+- **Decision:** `repo_root.name == "hub"` — the repo directory's name is the entire signal.
+- **Rationale:** Deterministic, zero-config, zero-heuristic. Existing Millhouse layout triggers it automatically; every other repo gets prefix-form naming.
+- **Applies to:** `_sibling.resolve_path`, and every consumer (mill-spawn, mill-setup, codeguide resolve.py).
+
+### Decision: One `_sibling.py` helper governs wiki, worktrees, and codeguide
+
+- **Decision:** `plugins/mill/scripts/_sibling.py` exposes `resolve_path(role, repo_root) -> Path`. Roles = `{"wiki", "codeguide", "worktrees"}` initially; extensible by string.
+- **Rationale:** Single source of truth. Future additions (e.g. `logs/`) land without re-deriving the hub-form rule.
+- **Applies to:** every batch touching sibling paths.
+
+### Decision: Resolve chain for codeguide ends with "run /codeguide-setup first"
+
+- **Decision:** Inline (walked up from cwd to git-toplevel) → `.codeguide-root` override at git-toplevel → sibling via `_sibling.resolve_path("codeguide", git_toplevel)` walked through the same path levels → bail with a friendly message.
+- **Rationale:** Predictable. Inline wins when the user set it up inline; sibling only activates when it exists.
+- **Applies to:** codeguide-plugin batch.
+
+### Decision: Plugin scripts always reference `${CLAUDE_PLUGIN_ROOT}`
+
+- **Decision:** Never assume the millhouse source is cloned on the user's machine. Rule already in `CLAUDE.md` as of this spec's first commit.
+- **Rationale:** Codeguide + mill plugins install on foreign repos; those repos cannot be expected to carry the source tree.
+- **Applies to:** codeguide-plugin + mill-integration batches, and any future sibling-touching work.
+
+### Decision: Sibling repo is always its own git repo
+
+- **Decision:** `codeguide-setup --sibling` runs `git init` (or `git clone --from-url`) on first use; later invocations from subfolders just `mkdir` + commit inside it.
+- **Rationale:** Versioned docs without polluting the target repo. Matches how mill-setup handles the wiki.
+- **Applies to:** codeguide-plugin batch.
+
+### Decision: Commit discipline diverges between inline and sibling
+
+- **Decision:** Inline → `@git-commit` stages cg files in the same commit. Sibling → `codeguide_commit.py` helper commits into the sibling repo independently; `@git-commit` does not try to stage its output.
+- **Rationale:** Cross-repo commits don't exist; sibling-repo gets its own history.
+- **Applies to:** codeguide-plugin batch.
+
+## All Files Touched
+
+New files:
+- `plugins/mill/scripts/_sibling.py`
+- `plugins/mill/unit_tests/test-sibling.py`
+- `plugins/codeguide/scripts/millpy/codeguide/codeguide_commit.py`
+
+Modified files:
+- `plugins/codeguide/scripts/millpy/codeguide/resolve.py`
+- `plugins/codeguide/skills/codeguide-setup/SKILL.md`
+- `plugins/codeguide/skills/codeguide-update/SKILL.md`
+- `plugins/mill/skills/git-commit/SKILL.md`
+- `plugins/mill/scripts/mill-spawn.py`
+- `plugins/mill/scripts/mill-setup.py` (if it reads wiki_path default today)
+- `plugins/mill/integration_tests/test-spawn.py`
+- `plugins/mill/integration_tests/test-merge.py`
+- `wiki/config.yaml` (drops `spawn.worktrees_dir` default; updates `<WIKI_PATH>` header-comment)
+- `specs/component/13-mill-codeguide.md` (one-line edit: "inline or sibling")

--- a/specs/component/00-plan/00-overview.md
+++ b/specs/component/00-plan/00-overview.md
@@ -38,13 +38,19 @@ batches:
 
 - **Decision:** `repo_root.name == "hub"` — the repo directory's name is the entire signal.
 - **Rationale:** Deterministic, zero-config, zero-heuristic. Existing Millhouse layout triggers it automatically; every other repo gets prefix-form naming.
-- **Applies to:** `_sibling.resolve_path`, and every consumer (mill-spawn, mill-setup, codeguide resolve.py).
+- **Applies to:** every implementation of the sibling-path rule (both plugin-local copies).
 
-### Decision: One `_sibling.py` helper governs wiki, worktrees, and codeguide
+### Decision: Each plugin ships its own `_sibling.py` — no cross-plugin import
 
-- **Decision:** `plugins/mill/scripts/_sibling.py` exposes `resolve_path(role, repo_root) -> Path`. Roles = `{"wiki", "codeguide", "worktrees"}` initially; extensible by string.
-- **Rationale:** Single source of truth. Future additions (e.g. `logs/`) land without re-deriving the hub-form rule.
-- **Applies to:** every batch touching sibling paths.
+- **Decision:** `plugins/mill/scripts/_sibling.py` and `plugins/codeguide/scripts/_sibling.py` are separate files with identical 3-line logic. Neither plugin imports from the other's `scripts/` directory.
+- **Rationale:** Plugin install paths are not guaranteed to be relative siblings of each other. Cross-plugin `${CLAUDE_PLUGIN_ROOT}/../mill/scripts/...` is fragile. Three lines of pure arithmetic is cheaper to duplicate than to share. Divergence risk is low; a pre-merge grep catches it if it ever happens.
+- **Applies to:** foundation batch (mill copy), codeguide-plugin batch (codeguide copy).
+
+### Decision: `_sibling.py` exposes a CLI entry point in addition to `resolve_path`
+
+- **Decision:** Both copies support `python _sibling.py <role> <repo_root>` → print resolved path on stdout, exit 0. Plus the Python import surface `from _sibling import resolve_path`.
+- **Rationale:** SKILL.md prose (mill-setup, codeguide-setup) invokes Python via subprocess — it needs a stable CLI. Python callers (mill-spawn) import directly.
+- **Applies to:** foundation batch; and a mirrored CLI in the codeguide copy for symmetry.
 
 ### Decision: Resolve chain for codeguide ends with "run /codeguide-setup first"
 
@@ -57,6 +63,12 @@ batches:
 - **Decision:** Never assume the millhouse source is cloned on the user's machine. Rule already in `CLAUDE.md` as of this spec's first commit.
 - **Rationale:** Codeguide + mill plugins install on foreign repos; those repos cannot be expected to carry the source tree.
 - **Applies to:** codeguide-plugin + mill-integration batches, and any future sibling-touching work.
+
+### Decision: Fix stale `millpy/codeguide/` paths before anything else in the codeguide-plugin batch
+
+- **Decision:** The four existing codeguide skills (`codeguide-setup`, `codeguide-update`, `codeguide-generate`, `codeguide-maintain`) reference `${CLAUDE_PLUGIN_ROOT}/scripts/millpy/codeguide/resolve.py`. That path does not exist — the file is at `${CLAUDE_PLUGIN_ROOT}/scripts/resolve.py`. The first card of the codeguide-plugin batch corrects all four files.
+- **Rationale:** The scoped-out bug blocks the sibling work: we cannot extend `resolve.py` if callers can't locate it in the first place. Fixing it is a precondition.
+- **Applies to:** codeguide-plugin batch (Card 3).
 
 ### Decision: Sibling repo is always its own git repo
 
@@ -75,15 +87,18 @@ batches:
 New files:
 - `plugins/mill/scripts/_sibling.py`
 - `plugins/mill/unit_tests/test-sibling.py`
-- `plugins/codeguide/scripts/millpy/codeguide/codeguide_commit.py`
+- `plugins/codeguide/scripts/_sibling.py`
+- `plugins/codeguide/scripts/codeguide_commit.py`
 
 Modified files:
-- `plugins/codeguide/scripts/millpy/codeguide/resolve.py`
+- `plugins/codeguide/scripts/resolve.py`
 - `plugins/codeguide/skills/codeguide-setup/SKILL.md`
 - `plugins/codeguide/skills/codeguide-update/SKILL.md`
+- `plugins/codeguide/skills/codeguide-generate/SKILL.md` (stale-path fix only)
+- `plugins/codeguide/skills/codeguide-maintain/SKILL.md` (stale-path fix only)
 - `plugins/mill/skills/git-commit/SKILL.md`
 - `plugins/mill/scripts/mill-spawn.py`
-- `plugins/mill/scripts/mill-setup.py` (if it reads wiki_path default today)
+- `plugins/mill/skills/mill-setup/SKILL.md`
 - `plugins/mill/integration_tests/test-spawn.py`
 - `plugins/mill/integration_tests/test-merge.py`
 - `wiki/config.yaml` (drops `spawn.worktrees_dir` default; updates `<WIKI_PATH>` header-comment)

--- a/specs/component/00-plan/01-foundation.md
+++ b/specs/component/00-plan/01-foundation.md
@@ -1,0 +1,45 @@
+# Batch: foundation
+
+```yaml
+task: codeguide sibling-mode + unified sibling-path convention
+batch: foundation
+cards: 2
+verify: python plugins/mill/unit_tests/test-sibling.py
+depends-on: []
+```
+
+## Batch Scope
+
+Introduce `_sibling.py` as the single source of truth for sibling-path resolution. Publishes `resolve_path(role, repo_root) -> Path` that every consumer (mill-spawn, mill-setup, codeguide `resolve.py`) calls. Ship it with its unit tests so subsequent batches have something stable to depend on.
+
+## Cards
+
+### Card 1: `_sibling.py` helper
+
+- **Reads:** `plugins/mill/scripts/_status.py`, `plugins/mill/scripts/_parent_branch.py` (pattern references for pure helpers), `CLAUDE.md` (convention reminders).
+- **Modifies:** (none)
+- **Creates:** `plugins/mill/scripts/_sibling.py`
+- **Requirements:**
+  - Expose `resolve_path(role: str, repo_root: Path) -> Path`.
+  - Hub-form detection: exactly `repo_root.name == "hub"`. No alternative spellings, no case-insensitive match — `Hub/` or `HUB/` is NOT hub-form.
+  - Hub-form branch returns `repo_root.parent / role`.
+  - Non-hub branch returns `repo_root.parent / f"{repo_root.name}.{role}"`.
+  - Module docstring explains the rule, the role whitelist (documentation, not enforced), and that the function NEVER touches disk — it is pure path arithmetic.
+  - No reliance on git or subprocess calls. `repo_root` is an input; callers are responsible for resolving git-toplevel.
+- **Commit:** `feat(sibling): add _sibling.py helper for uniform sibling-path resolution`
+
+### Card 2: unit test for `_sibling.py`
+
+- **Reads:** `plugins/mill/scripts/_sibling.py` (just authored), `plugins/mill/unit_tests/test-parent-branch.py` (template), `plugins/mill/unit_tests/run-all.py`.
+- **Modifies:** (none)
+- **Creates:** `plugins/mill/unit_tests/test-sibling.py`
+- **Requirements:**
+  - Cover every combination: role ∈ `{"wiki", "codeguide", "worktrees"}`, repo_root names `"hub"` and `"Models"` at minimum.
+  - Assert hub-form path for `hub` parent, prefix-form path for every other name (including edge cases like empty-looking names or names with dots in them — the helper treats `.` as an ordinary character).
+  - Verify the function does NOT touch disk (no mkdir, no stat). Using fake `Path` objects pointing at non-existent locations should return a valid computed path regardless.
+  - Follow the same test-file scaffolding as the rest of `plugins/mill/unit_tests/` (sys.path insert, top-level `main()`, exit-code return).
+- **Commit:** `test(sibling): unit tests for _sibling.resolve_path`
+
+## Batch Tests
+
+`verify:` runs `python plugins/mill/unit_tests/test-sibling.py`. On pass, `_sibling.py` is available to every downstream batch. The full unit-test runner (`run-all.py`) also picks up the new test file automatically — no manual wiring.

--- a/specs/component/00-plan/01-foundation.md
+++ b/specs/component/00-plan/01-foundation.md
@@ -10,36 +10,42 @@ depends-on: []
 
 ## Batch Scope
 
-Introduce `_sibling.py` as the single source of truth for sibling-path resolution. Publishes `resolve_path(role, repo_root) -> Path` that every consumer (mill-spawn, mill-setup, codeguide `resolve.py`) calls. Ship it with its unit tests so subsequent batches have something stable to depend on.
+Introduce `_sibling.py` as the sibling-path helper for the mill plugin. Publishes `resolve_path(role, repo_root) -> Path` as the Python API and a `__main__` CLI entry point (`python _sibling.py <role> <repo_root>` → print resolved path). Ships with its unit test so downstream batches depend on something stable.
+
+The `_sibling.py` in the codeguide plugin is created in a later batch (codeguide-plugin Card 4); this batch only creates mill's copy.
 
 ## Cards
 
-### Card 1: `_sibling.py` helper
+### Card 1: `plugins/mill/scripts/_sibling.py`
 
-- **Reads:** `plugins/mill/scripts/_status.py`, `plugins/mill/scripts/_parent_branch.py` (pattern references for pure helpers), `CLAUDE.md` (convention reminders).
+- **Reads:** `plugins/mill/scripts/_parent_branch.py` (pattern reference for pure helpers), `plugins/mill/scripts/_subprocess_util.py` (pattern reference for modules that expose both Python API and a small CLI), `CLAUDE.md` (convention reminders — `${CLAUDE_PLUGIN_ROOT}` rule; no `__main__`-smoke-tests in helpers, but CLI entry points are allowed because they are production surface, not tests).
 - **Modifies:** (none)
 - **Creates:** `plugins/mill/scripts/_sibling.py`
 - **Requirements:**
   - Expose `resolve_path(role: str, repo_root: Path) -> Path`.
-  - Hub-form detection: exactly `repo_root.name == "hub"`. No alternative spellings, no case-insensitive match — `Hub/` or `HUB/` is NOT hub-form.
+  - Hub-form detection: exactly `repo_root.name == "hub"`. No alternative spellings, no case-insensitive match — `Hub/` or `HUB/` is NOT hub-form. Document this in the module docstring.
   - Hub-form branch returns `repo_root.parent / role`.
   - Non-hub branch returns `repo_root.parent / f"{repo_root.name}.{role}"`.
-  - Module docstring explains the rule, the role whitelist (documentation, not enforced), and that the function NEVER touches disk — it is pure path arithmetic.
-  - No reliance on git or subprocess calls. `repo_root` is an input; callers are responsible for resolving git-toplevel.
-- **Commit:** `feat(sibling): add _sibling.py helper for uniform sibling-path resolution`
+  - `role` is treated as a free string but the docstring lists the known roles (`"wiki"`, `"codeguide"`, `"worktrees"`). No runtime validation — callers pass what they need.
+  - Pure path arithmetic. NEVER touches disk (no `mkdir`, no `stat`, no `resolve()`). `repo_root` is an input; callers are responsible for resolving git-toplevel.
+  - **CLI entry point** (`if __name__ == "__main__":`) — parses `<role> <repo_root>` positionally, prints the resolved path to stdout, exits 0. Bad args print a one-line error to stderr and exit 2. This is production surface (used by SKILL.md subprocess invocations), not a smoke test. Keep it minimal: `import sys`, `argparse` or even just `sys.argv[1:]`. No asserts.
+  - Module docstring calls out the rule, the CLI, and the fact that a parallel identical copy lives in the codeguide plugin — so anyone editing one remembers to sync the other.
+- **Commit:** `feat(sibling): add _sibling.py helper + CLI for mill plugin`
 
-### Card 2: unit test for `_sibling.py`
+### Card 2: `plugins/mill/unit_tests/test-sibling.py`
 
 - **Reads:** `plugins/mill/scripts/_sibling.py` (just authored), `plugins/mill/unit_tests/test-parent-branch.py` (template), `plugins/mill/unit_tests/run-all.py`.
 - **Modifies:** (none)
 - **Creates:** `plugins/mill/unit_tests/test-sibling.py`
 - **Requirements:**
   - Cover every combination: role ∈ `{"wiki", "codeguide", "worktrees"}`, repo_root names `"hub"` and `"Models"` at minimum.
-  - Assert hub-form path for `hub` parent, prefix-form path for every other name (including edge cases like empty-looking names or names with dots in them — the helper treats `.` as an ordinary character).
-  - Verify the function does NOT touch disk (no mkdir, no stat). Using fake `Path` objects pointing at non-existent locations should return a valid computed path regardless.
+  - Assert hub-form path for `hub` parent, prefix-form path for every other name (including edge cases like names with dots in them — the helper treats `.` as an ordinary character).
+  - Assert that `Hub/` and `HUB/` produce prefix-form, NOT hub-form (case-sensitivity).
+  - Verify the function does NOT touch disk — using fake `Path` objects pointing at non-existent locations should return a valid computed path regardless.
+  - Cover the CLI entry point: invoke via `subprocess.run([sys.executable, module_path, role, repo_root])`, assert stdout is the expected path. Cover the arg-error path too (exit 2).
   - Follow the same test-file scaffolding as the rest of `plugins/mill/unit_tests/` (sys.path insert, top-level `main()`, exit-code return).
-- **Commit:** `test(sibling): unit tests for _sibling.resolve_path`
+- **Commit:** `test(sibling): unit tests for _sibling.resolve_path + CLI`
 
 ## Batch Tests
 
-`verify:` runs `python plugins/mill/unit_tests/test-sibling.py`. On pass, `_sibling.py` is available to every downstream batch. The full unit-test runner (`run-all.py`) also picks up the new test file automatically — no manual wiring.
+`verify:` runs `python plugins/mill/unit_tests/test-sibling.py`. On pass, `_sibling.py` is stable for downstream batches. The full unit-test runner (`run-all.py`) picks up the new test automatically — no wiring needed.

--- a/specs/component/00-plan/02-codeguide-plugin.md
+++ b/specs/component/00-plan/02-codeguide-plugin.md
@@ -3,95 +3,125 @@
 ```yaml
 task: codeguide sibling-mode + unified sibling-path convention
 batch: codeguide-plugin
-cards: 5
+cards: 7
 verify: null
 depends-on: [foundation]
 ```
 
 ## Batch Scope
 
-Upgrade the codeguide plugin to support the sibling mode. Changes are split between the resolver (new lookup chain), the setup skill (new --sibling / --from-url flags + auto-git-init), the update skill (new commit helper), and a new `codeguide_commit.py` script that handles mode-aware commits.
+Upgrade the codeguide plugin to support sibling mode. Seven cards:
 
-No `verify:` command at the batch level — the plugin is pure prose + scripts that are exercised by humans or by mill-go in later tasks. Unit-level testing for pure-Python pieces is covered by the batch's individual card tests where practical; the full integration happens in a later spec when mill-v2 drives a codeguide seed end-to-end (spec 13).
+1. **Card 3** — fix the stale `millpy/codeguide/` path references in all four codeguide SKILL.md files (pre-existing bug; see spec).
+2. **Card 4** — create `plugins/codeguide/scripts/_sibling.py` as a codeguide-local copy of the mill sibling helper. Zero cross-plugin imports.
+3. **Card 5** — extend `plugins/codeguide/scripts/resolve.py` with the sibling lookup chain (inline → `.codeguide-root` → sibling via local `_sibling`).
+4. **Card 6** — create `plugins/codeguide/scripts/codeguide_commit.py` (mode-aware commit helper).
+5. **Card 7** — rewrite `codeguide-setup` SKILL.md for `--sibling` / `--from-url` flags.
+6. **Card 8** — rewrite `codeguide-update` SKILL.md to call `codeguide_commit.py` and handle multi-codeguide-per-commit grouping.
+7. **Card 9** — `@git-commit` step 2 note about sibling-mode interaction.
 
-### Batch-local decision
+### Batch-local decision: no batch-level `verify:`
 
-Unlike batch-level `verify:` on other batches, this batch deliberately skips repeatable verification. The reason: the skill markdown is executed by Claude at runtime; there is no static test that catches wording regressions. A later spec that wires mill-plan through codeguide-setup on a real sibling will double as the integration test.
+Unlike batches with runnable code, this batch is mostly skill markdown + pure-Python modules. The two Python modules (`_sibling.py` and `codeguide_commit.py`) get inline module-level validation via their own unit tests if added (out of scope for this iteration — we validate manually on the first real sibling setup). The SKILL.md files are executed by Claude at runtime; there is no static test that catches wording regressions. End-to-end validation happens when the engineer runs `/codeguide-setup --sibling` on the target third-party repo as the first real user of this code.
 
 ## Cards
 
-### Card 3: extend codeguide `resolve.py` with sibling lookup
+### Card 3: fix stale `millpy/codeguide/` paths in all four codeguide skills
 
-- **Reads:** `plugins/codeguide/scripts/millpy/codeguide/resolve.py`, `plugins/mill/scripts/_sibling.py`, `plugins/codeguide/skills/codeguide-setup/SKILL.md`.
-- **Modifies:** `plugins/codeguide/scripts/millpy/codeguide/resolve.py`
+- **Reads:** `plugins/codeguide/skills/codeguide-setup/SKILL.md`, `plugins/codeguide/skills/codeguide-update/SKILL.md`, `plugins/codeguide/skills/codeguide-generate/SKILL.md`, `plugins/codeguide/skills/codeguide-maintain/SKILL.md`, `plugins/codeguide/scripts/resolve.py` (confirm path of the real script).
+- **Modifies:** all four SKILL.md files above.
+- **Creates:** (none)
+- **Requirements:**
+  - Replace every occurrence of `${CLAUDE_PLUGIN_ROOT}/scripts/millpy/codeguide/resolve.py` with `${CLAUDE_PLUGIN_ROOT}/scripts/resolve.py`. There are currently four such references, one per skill — grep to confirm no others slipped in.
+  - Do not touch other parts of the skills. This card is scoped strictly to the path fix.
+  - Preserve `---` YAML frontmatter headers unchanged (these are SKILL.md files; `---` is allowed).
+- **Commit:** `fix(codeguide): correct stale millpy/codeguide/ paths to flat scripts/`
+
+### Card 4: `plugins/codeguide/scripts/_sibling.py` (codeguide-local copy)
+
+- **Reads:** `plugins/mill/scripts/_sibling.py` (the authoritative reference from Card 1), `plugins/codeguide/scripts/resolve.py` (pattern for scripts in this plugin).
+- **Modifies:** (none)
+- **Creates:** `plugins/codeguide/scripts/_sibling.py`
+- **Requirements:**
+  - Content is IDENTICAL to `plugins/mill/scripts/_sibling.py` — same `resolve_path` function, same CLI entry point, same docstring approach.
+  - Docstring explicitly states: "This file is a deliberate duplicate of `plugins/mill/scripts/_sibling.py`. Each plugin carries its own copy to avoid any cross-plugin import assumption. If you edit one, grep for the other and apply the same change."
+  - No imports from the mill plugin. No reference to `plugins/mill/` paths. Self-contained.
+- **Commit:** `feat(codeguide): add local _sibling.py (identical-twin of mill's)`
+
+### Card 5: extend codeguide `resolve.py` with sibling lookup
+
+- **Reads:** `plugins/codeguide/scripts/resolve.py`, `plugins/codeguide/scripts/_sibling.py` (post-Card-4), `plugins/codeguide/skills/codeguide-setup/SKILL.md` (post-Card-3 path fix).
+- **Modifies:** `plugins/codeguide/scripts/resolve.py`
 - **Creates:** (none)
 - **Requirements:**
   - Preserve the existing inline walk-up lookup unchanged.
   - After the inline walk fails, check for `<git-toplevel>/.codeguide-root`. If present, read the single-line path (absolute or relative-to-toplevel); treat it as the sibling anchor.
-  - If no `.codeguide-root`, compute the sibling anchor by invoking `_sibling.resolve_path("codeguide", git_toplevel)`. Import from the mill plugin via `${CLAUDE_PLUGIN_ROOT}/../mill/scripts/_sibling.py` — resolve the path at call time; do NOT require mill source to be present at import time. If mill plugin is not installed, fail with a readable error.
+  - If no `.codeguide-root`, compute the sibling anchor by importing from the LOCAL `_sibling` module (`from _sibling import resolve_path`), called as `resolve_path("codeguide", git_toplevel)`. Same-directory import, no `${CLAUDE_PLUGIN_ROOT}/../...` nonsense.
   - Sibling walk mirrors the inline walk: for each level from cwd to git-toplevel, check `<sibling_anchor>/<rel-path>/_codeguide/Overview.md`.
-  - Return a structured result that callers can destructure: `{mode: "inline" | "sibling", cg_root: Path, sibling_anchor: Path | None}`.
+  - Return a structured result callers can destructure: `{mode: "inline" | "sibling", cg_root: Path, sibling_anchor: Path | None}`.
   - Exit-code 1 with a helpful message when nothing is found ("run /codeguide-setup first [--sibling]").
-- **Commit:** `feat(codeguide): resolve.py adds sibling lookup chain`
+  - Preserve any existing public API signatures used by the other codeguide skills.
+- **Commit:** `feat(codeguide): resolve.py adds sibling lookup chain (inline / .codeguide-root / sibling)`
 
-### Card 4: `codeguide_commit.py` helper
+### Card 6: `plugins/codeguide/scripts/codeguide_commit.py`
 
-- **Reads:** `plugins/codeguide/scripts/millpy/codeguide/resolve.py` (post-Card-3 state), `plugins/mill/skills/git-commit/SKILL.md`.
+- **Reads:** `plugins/codeguide/scripts/resolve.py` (post-Card-5 state), `plugins/mill/skills/git-commit/SKILL.md`, `plugins/mill/scripts/_subprocess_util.py` (pattern for git-invoking helpers).
 - **Modifies:** (none)
-- **Creates:** `plugins/codeguide/scripts/millpy/codeguide/codeguide_commit.py`
+- **Creates:** `plugins/codeguide/scripts/codeguide_commit.py`
 - **Requirements:**
-  - Accept arguments: list of changed cg-doc paths (`--file <path>` repeatable) and commit message (`-m <msg>`).
-  - Call `resolve.py` to determine mode.
-  - Inline mode → `git add <file> …` in the current repo (target repo). Do not commit — leave that to the outer `@git-commit` skill that invoked us.
-  - Sibling mode → `git -C <sibling_anchor> add <file> …` (the file paths are already rooted under the sibling) and `git -C <sibling_anchor> commit -m <msg>`. Commit in the sibling repo directly. Return 0 on success.
+  - CLI args: `--file <path>` (repeatable), `-m <msg>`.
+  - Call `resolve.py` (or directly import its logic) to determine mode.
+  - **Inline mode** → `git add <file> …` in the current repo (target repo). Do NOT commit — leave that to the outer `@git-commit` skill that invoked us.
+  - **Sibling mode** → `git -C <sibling_anchor> add <file> …` (the file paths are already rooted under the sibling) and `git -C <sibling_anchor> commit -m <msg>`. Commit in the sibling repo directly. Return 0 on success.
   - Stdout is a one-line JSON summary: `{"mode": "...", "committed": true|false, "files": [...]}`. Stderr carries subprocess transcripts.
-- **Commit:** `feat(codeguide): commit.py helper for mode-aware staging/commit`
+  - No cross-plugin imports. If subprocess-to-git needs argument escaping, handle it locally; do not reach into mill's `_subprocess_util`.
+- **Commit:** `feat(codeguide): codeguide_commit.py mode-aware staging/commit helper`
 
-### Card 5: rewrite `codeguide-setup` SKILL.md for sibling mode
+### Card 7: rewrite `codeguide-setup` SKILL.md for sibling mode
 
-- **Reads:** `plugins/codeguide/skills/codeguide-setup/SKILL.md`, `plugins/codeguide/scripts/millpy/codeguide/resolve.py` (post-Card-3), `plugins/mill/scripts/_sibling.py`.
+- **Reads:** `plugins/codeguide/skills/codeguide-setup/SKILL.md` (post-Card-3), `plugins/codeguide/scripts/resolve.py` (post-Card-5), `plugins/codeguide/scripts/_sibling.py`.
 - **Modifies:** `plugins/codeguide/skills/codeguide-setup/SKILL.md`
 - **Creates:** (none)
 - **Requirements:**
-  - New argument-hint: `[--sibling] [--from-url <git-url>] [.cs .py .ts]`.
+  - **Preserve the existing `---` YAML frontmatter header** (`name:`, `description:`, `argument-hint:`). Update `argument-hint:` to `[--sibling] [--from-url <git-url>] [.cs .py .ts]`. Do not convert frontmatter to fenced `yaml` — SKILL.md uses `---` per project convention.
   - Without `--sibling`: existing behaviour unchanged (inline setup in cwd-rooted `_codeguide/`).
   - With `--sibling`:
-    - Resolve sibling-anchor via `_sibling.resolve_path("codeguide", git_toplevel)`.
-    - If anchor doesn't exist: `git init` it (locally, no remote), or `git clone --from-url <url>` if provided.
+    - Resolve sibling-anchor by invoking `python ${CLAUDE_PLUGIN_ROOT}/scripts/_sibling.py codeguide <git-toplevel>` via subprocess. Parse the stdout path.
+    - If anchor doesn't exist: `git init` it (locally, no remote), or `git clone <url>` if `--from-url` provided.
     - Compute `rel-path = cwd.relative_to(git_toplevel)`.
     - Create `<anchor>/<rel-path>/_codeguide/` and copy plugin-owned templates into it.
     - Commit in the sibling repo with message `codeguide-setup: init <rel-path>` (or `init root` when rel-path is empty).
-  - Mode the skill writes into the overview's frontmatter: `mode: inline | sibling`. Resolve.py reads this as a cross-check.
   - Subfolder-refresh and new-subfolder-activation modes (current) behave correctly when invoked inside sibling mode — they mirror into `<anchor>/<rel-path>/` instead of cwd.
   - Mention the `.codeguide-root` override file but do NOT auto-create it; users who want a non-default sibling anchor create it themselves.
   - **Never modify the target repo.** Don't touch `.gitignore`, don't drop marker files, don't auto-commit anything into it.
+  - Drop any notion of a `mode:` field written into Overview.md frontmatter — the spec's decisions section does not include such a field, and the resolve chain is deterministic without it.
 - **Commit:** `feat(codeguide): setup skill gains --sibling / --from-url flags`
 
-### Card 6: rewrite `codeguide-update` SKILL.md to call `codeguide_commit.py`
+### Card 8: rewrite `codeguide-update` SKILL.md to call `codeguide_commit.py`
 
-- **Reads:** `plugins/codeguide/skills/codeguide-update/SKILL.md`, `plugins/codeguide/scripts/millpy/codeguide/codeguide_commit.py` (post-Card-4).
+- **Reads:** `plugins/codeguide/skills/codeguide-update/SKILL.md` (post-Card-3), `plugins/codeguide/scripts/codeguide_commit.py` (post-Card-6), `plugins/codeguide/scripts/resolve.py` (post-Card-5).
 - **Modifies:** `plugins/codeguide/skills/codeguide-update/SKILL.md`
 - **Creates:** (none)
 - **Requirements:**
-  - After updating cg-doc files, invoke `codeguide_commit.py --file … --file … -m "…"` with the actual file list and a generated message (matching current skill's style).
-  - In the "Does not commit" disclaimer at the top: change wording from "Does not commit" to "In inline mode, the outer `@git-commit` skill commits; in sibling mode, codeguide_commit.py commits in the sibling repo."
-  - Group-by-root logic: the skill takes a staged-diff file list, walks it through `resolve.py` to find each file's cg-root, groups, and processes each group (update + commit) independently. Covers the multi-codeguide case where one commit touches two subfolder codeguides.
+  - Preserve the existing `---` YAML frontmatter.
+  - Replace the "Does not commit" disclaimer at the top: "In inline mode, the outer `@git-commit` skill commits; in sibling mode, codeguide_commit.py commits in the sibling repo."
+  - After updating cg-doc files, invoke `python ${CLAUDE_PLUGIN_ROOT}/scripts/codeguide_commit.py --file … --file … -m "…"` with the actual file list and a generated message.
+  - **Multi-codeguide grouping:** when the staged diff touches files under two subfolders that each have their own codeguide, the skill walks each diff-file through `resolve.py` to find its governing cg-root, groups files by root, and processes each group (update + commit) independently.
   - Preserve the existing "update stale docs / flag orphan / update Overview routing" logic verbatim.
-- **Commit:** `feat(codeguide): update skill uses commit.py + group-by-root`
+- **Commit:** `feat(codeguide): update skill uses codeguide_commit.py + group-by-root`
 
-### Card 7: update `@git-commit` step 2 to mention sibling mode
+### Card 9: `@git-commit` step 2 note about sibling mode
 
-- **Reads:** `plugins/mill/skills/git-commit/SKILL.md`, `plugins/codeguide/skills/codeguide-update/SKILL.md` (post-Card-6).
+- **Reads:** `plugins/mill/skills/git-commit/SKILL.md`, `plugins/codeguide/skills/codeguide-update/SKILL.md` (post-Card-8).
 - **Modifies:** `plugins/mill/skills/git-commit/SKILL.md`
 - **Creates:** (none)
 - **Requirements:**
   - Step 2 continues to invoke `@codeguide:codeguide-update` when `_codeguide/Overview.md` exists anywhere (inline OR sibling — resolve.py handles both).
   - Add a note: "In sibling mode, codeguide-update commits into the sibling repo itself via codeguide_commit.py. Do not attempt to stage sibling-rooted files in this commit — the sibling has its own history."
   - Keep the staging rule for inline mode intact.
+  - Preserve the existing `---` YAML frontmatter.
 - **Commit:** `feat(git-commit): note sibling-mode interaction with codeguide-update`
 
 ## Batch Tests
 
-None runnable automatically in this batch. The plugin changes are exercised when codeguide is actually used on a sibling repo — which happens in spec 13's eventual implementation, or when the engineer runs this on the upcoming third-party codebase. Integration test for sibling setup is out of scope for this spec (would require either a live sibling-init test or stubbing `git init`).
-
-Manual smoke: on the engineer's target third-party repo, run `/codeguide-setup --sibling` from a subfolder. Expect: sibling dir created at `<parent>/<repo>.codeguide/<rel-path>/_codeguide/`, initial commit in sibling repo, nothing written to target repo.
+No automatic batch verify. End-to-end validation happens when the engineer runs `/codeguide-setup --sibling` on the target third-party repo; a clean sibling repo created, zero files written to target repo, one commit landed in sibling. That is the smoke test; it happens outside mill-v2's test infrastructure.

--- a/specs/component/00-plan/02-codeguide-plugin.md
+++ b/specs/component/00-plan/02-codeguide-plugin.md
@@ -1,0 +1,97 @@
+# Batch: codeguide-plugin
+
+```yaml
+task: codeguide sibling-mode + unified sibling-path convention
+batch: codeguide-plugin
+cards: 5
+verify: null
+depends-on: [foundation]
+```
+
+## Batch Scope
+
+Upgrade the codeguide plugin to support the sibling mode. Changes are split between the resolver (new lookup chain), the setup skill (new --sibling / --from-url flags + auto-git-init), the update skill (new commit helper), and a new `codeguide_commit.py` script that handles mode-aware commits.
+
+No `verify:` command at the batch level — the plugin is pure prose + scripts that are exercised by humans or by mill-go in later tasks. Unit-level testing for pure-Python pieces is covered by the batch's individual card tests where practical; the full integration happens in a later spec when mill-v2 drives a codeguide seed end-to-end (spec 13).
+
+### Batch-local decision
+
+Unlike batch-level `verify:` on other batches, this batch deliberately skips repeatable verification. The reason: the skill markdown is executed by Claude at runtime; there is no static test that catches wording regressions. A later spec that wires mill-plan through codeguide-setup on a real sibling will double as the integration test.
+
+## Cards
+
+### Card 3: extend codeguide `resolve.py` with sibling lookup
+
+- **Reads:** `plugins/codeguide/scripts/millpy/codeguide/resolve.py`, `plugins/mill/scripts/_sibling.py`, `plugins/codeguide/skills/codeguide-setup/SKILL.md`.
+- **Modifies:** `plugins/codeguide/scripts/millpy/codeguide/resolve.py`
+- **Creates:** (none)
+- **Requirements:**
+  - Preserve the existing inline walk-up lookup unchanged.
+  - After the inline walk fails, check for `<git-toplevel>/.codeguide-root`. If present, read the single-line path (absolute or relative-to-toplevel); treat it as the sibling anchor.
+  - If no `.codeguide-root`, compute the sibling anchor by invoking `_sibling.resolve_path("codeguide", git_toplevel)`. Import from the mill plugin via `${CLAUDE_PLUGIN_ROOT}/../mill/scripts/_sibling.py` — resolve the path at call time; do NOT require mill source to be present at import time. If mill plugin is not installed, fail with a readable error.
+  - Sibling walk mirrors the inline walk: for each level from cwd to git-toplevel, check `<sibling_anchor>/<rel-path>/_codeguide/Overview.md`.
+  - Return a structured result that callers can destructure: `{mode: "inline" | "sibling", cg_root: Path, sibling_anchor: Path | None}`.
+  - Exit-code 1 with a helpful message when nothing is found ("run /codeguide-setup first [--sibling]").
+- **Commit:** `feat(codeguide): resolve.py adds sibling lookup chain`
+
+### Card 4: `codeguide_commit.py` helper
+
+- **Reads:** `plugins/codeguide/scripts/millpy/codeguide/resolve.py` (post-Card-3 state), `plugins/mill/skills/git-commit/SKILL.md`.
+- **Modifies:** (none)
+- **Creates:** `plugins/codeguide/scripts/millpy/codeguide/codeguide_commit.py`
+- **Requirements:**
+  - Accept arguments: list of changed cg-doc paths (`--file <path>` repeatable) and commit message (`-m <msg>`).
+  - Call `resolve.py` to determine mode.
+  - Inline mode → `git add <file> …` in the current repo (target repo). Do not commit — leave that to the outer `@git-commit` skill that invoked us.
+  - Sibling mode → `git -C <sibling_anchor> add <file> …` (the file paths are already rooted under the sibling) and `git -C <sibling_anchor> commit -m <msg>`. Commit in the sibling repo directly. Return 0 on success.
+  - Stdout is a one-line JSON summary: `{"mode": "...", "committed": true|false, "files": [...]}`. Stderr carries subprocess transcripts.
+- **Commit:** `feat(codeguide): commit.py helper for mode-aware staging/commit`
+
+### Card 5: rewrite `codeguide-setup` SKILL.md for sibling mode
+
+- **Reads:** `plugins/codeguide/skills/codeguide-setup/SKILL.md`, `plugins/codeguide/scripts/millpy/codeguide/resolve.py` (post-Card-3), `plugins/mill/scripts/_sibling.py`.
+- **Modifies:** `plugins/codeguide/skills/codeguide-setup/SKILL.md`
+- **Creates:** (none)
+- **Requirements:**
+  - New argument-hint: `[--sibling] [--from-url <git-url>] [.cs .py .ts]`.
+  - Without `--sibling`: existing behaviour unchanged (inline setup in cwd-rooted `_codeguide/`).
+  - With `--sibling`:
+    - Resolve sibling-anchor via `_sibling.resolve_path("codeguide", git_toplevel)`.
+    - If anchor doesn't exist: `git init` it (locally, no remote), or `git clone --from-url <url>` if provided.
+    - Compute `rel-path = cwd.relative_to(git_toplevel)`.
+    - Create `<anchor>/<rel-path>/_codeguide/` and copy plugin-owned templates into it.
+    - Commit in the sibling repo with message `codeguide-setup: init <rel-path>` (or `init root` when rel-path is empty).
+  - Mode the skill writes into the overview's frontmatter: `mode: inline | sibling`. Resolve.py reads this as a cross-check.
+  - Subfolder-refresh and new-subfolder-activation modes (current) behave correctly when invoked inside sibling mode — they mirror into `<anchor>/<rel-path>/` instead of cwd.
+  - Mention the `.codeguide-root` override file but do NOT auto-create it; users who want a non-default sibling anchor create it themselves.
+  - **Never modify the target repo.** Don't touch `.gitignore`, don't drop marker files, don't auto-commit anything into it.
+- **Commit:** `feat(codeguide): setup skill gains --sibling / --from-url flags`
+
+### Card 6: rewrite `codeguide-update` SKILL.md to call `codeguide_commit.py`
+
+- **Reads:** `plugins/codeguide/skills/codeguide-update/SKILL.md`, `plugins/codeguide/scripts/millpy/codeguide/codeguide_commit.py` (post-Card-4).
+- **Modifies:** `plugins/codeguide/skills/codeguide-update/SKILL.md`
+- **Creates:** (none)
+- **Requirements:**
+  - After updating cg-doc files, invoke `codeguide_commit.py --file … --file … -m "…"` with the actual file list and a generated message (matching current skill's style).
+  - In the "Does not commit" disclaimer at the top: change wording from "Does not commit" to "In inline mode, the outer `@git-commit` skill commits; in sibling mode, codeguide_commit.py commits in the sibling repo."
+  - Group-by-root logic: the skill takes a staged-diff file list, walks it through `resolve.py` to find each file's cg-root, groups, and processes each group (update + commit) independently. Covers the multi-codeguide case where one commit touches two subfolder codeguides.
+  - Preserve the existing "update stale docs / flag orphan / update Overview routing" logic verbatim.
+- **Commit:** `feat(codeguide): update skill uses commit.py + group-by-root`
+
+### Card 7: update `@git-commit` step 2 to mention sibling mode
+
+- **Reads:** `plugins/mill/skills/git-commit/SKILL.md`, `plugins/codeguide/skills/codeguide-update/SKILL.md` (post-Card-6).
+- **Modifies:** `plugins/mill/skills/git-commit/SKILL.md`
+- **Creates:** (none)
+- **Requirements:**
+  - Step 2 continues to invoke `@codeguide:codeguide-update` when `_codeguide/Overview.md` exists anywhere (inline OR sibling — resolve.py handles both).
+  - Add a note: "In sibling mode, codeguide-update commits into the sibling repo itself via codeguide_commit.py. Do not attempt to stage sibling-rooted files in this commit — the sibling has its own history."
+  - Keep the staging rule for inline mode intact.
+- **Commit:** `feat(git-commit): note sibling-mode interaction with codeguide-update`
+
+## Batch Tests
+
+None runnable automatically in this batch. The plugin changes are exercised when codeguide is actually used on a sibling repo — which happens in spec 13's eventual implementation, or when the engineer runs this on the upcoming third-party codebase. Integration test for sibling setup is out of scope for this spec (would require either a live sibling-init test or stubbing `git init`).
+
+Manual smoke: on the engineer's target third-party repo, run `/codeguide-setup --sibling` from a subfolder. Expect: sibling dir created at `<parent>/<repo>.codeguide/<rel-path>/_codeguide/`, initial commit in sibling repo, nothing written to target repo.

--- a/specs/component/00-plan/02-codeguide-plugin.md
+++ b/specs/component/00-plan/02-codeguide-plugin.md
@@ -65,16 +65,21 @@ Unlike batches with runnable code, this batch is mostly skill markdown + pure-Py
 
 ### Card 6: `plugins/codeguide/scripts/codeguide_commit.py`
 
-- **Reads:** `plugins/codeguide/scripts/resolve.py` (post-Card-5 state), `plugins/mill/skills/git-commit/SKILL.md`, `plugins/mill/scripts/_subprocess_util.py` (pattern for git-invoking helpers).
+- **Reads:** `plugins/codeguide/scripts/resolve.py` (post-Card-5 state, for understanding the mode/anchor contract — NOT for re-invocation at commit time), `plugins/mill/skills/git-commit/SKILL.md`, `plugins/mill/scripts/_subprocess_util.py` (pattern for git-invoking helpers).
 - **Modifies:** (none)
 - **Creates:** `plugins/codeguide/scripts/codeguide_commit.py`
 - **Requirements:**
-  - CLI args: `--file <path>` (repeatable), `-m <msg>`.
-  - Call `resolve.py` (or directly import its logic) to determine mode.
-  - **Inline mode** → `git add <file> …` in the current repo (target repo). Do NOT commit — leave that to the outer `@git-commit` skill that invoked us.
-  - **Sibling mode** → `git -C <sibling_anchor> add <file> …` (the file paths are already rooted under the sibling) and `git -C <sibling_anchor> commit -m <msg>`. Commit in the sibling repo directly. Return 0 on success.
+  - CLI args (all explicit — the helper does NOT re-run resolve.py):
+    - `--mode {inline,sibling}` (required).
+    - `--sibling-anchor <path>` (required when `--mode sibling`; absolute path to the sibling repo root). Ignored when `--mode inline`.
+    - `--file <path>` (repeatable; absolute paths). For inline mode these are paths inside the target repo; for sibling mode they are paths inside the sibling repo tree.
+    - `-m <msg>`.
+  - The caller (`codeguide-update`) already holds the mode + anchor from its own `resolve.py` call earlier in the flow. Passing those in explicitly avoids re-running `resolve.py` from a potentially-different cwd, and avoids coupling this helper to import-time side effects.
+  - **Inline mode** → `git add <file> …` in the current repo (target repo, i.e. cwd). Do NOT commit — leave that to the outer `@git-commit` skill that invoked us.
+  - **Sibling mode** → `git -C <sibling-anchor> add <file> …` and `git -C <sibling-anchor> commit -m <msg>`. Commit in the sibling repo directly. Return 0 on success.
   - Stdout is a one-line JSON summary: `{"mode": "...", "committed": true|false, "files": [...]}`. Stderr carries subprocess transcripts.
   - No cross-plugin imports. If subprocess-to-git needs argument escaping, handle it locally; do not reach into mill's `_subprocess_util`.
+  - Argument validation: missing `--mode`, invalid value, or sibling mode without `--sibling-anchor` → exit 2 with a one-line stderr error.
 - **Commit:** `feat(codeguide): codeguide_commit.py mode-aware staging/commit helper`
 
 ### Card 7: rewrite `codeguide-setup` SKILL.md for sibling mode
@@ -105,8 +110,8 @@ Unlike batches with runnable code, this batch is mostly skill markdown + pure-Py
 - **Requirements:**
   - Preserve the existing `---` YAML frontmatter.
   - Replace the "Does not commit" disclaimer at the top: "In inline mode, the outer `@git-commit` skill commits; in sibling mode, codeguide_commit.py commits in the sibling repo."
-  - After updating cg-doc files, invoke `python ${CLAUDE_PLUGIN_ROOT}/scripts/codeguide_commit.py --file … --file … -m "…"` with the actual file list and a generated message.
-  - **Multi-codeguide grouping:** when the staged diff touches files under two subfolders that each have their own codeguide, the skill walks each diff-file through `resolve.py` to find its governing cg-root, groups files by root, and processes each group (update + commit) independently.
+  - After updating cg-doc files in a given cg-root's group, invoke `python ${CLAUDE_PLUGIN_ROOT}/scripts/codeguide_commit.py --mode <mode> [--sibling-anchor <path>] --file … --file … -m "…"` with the mode and anchor that `resolve.py` returned for THAT group, the actual file list, and a generated message. Never re-invoke `resolve.py` from the helper — pass what we already know.
+  - **Multi-codeguide grouping:** when the staged diff touches files under two subfolders that each have their own codeguide, the skill walks each diff-file through `resolve.py` to find its governing cg-root + mode + anchor, groups files by root, and processes each group (update + commit) independently with the group's own mode/anchor flags.
   - Preserve the existing "update stale docs / flag orphan / update Overview routing" logic verbatim.
 - **Commit:** `feat(codeguide): update skill uses codeguide_commit.py + group-by-root`
 

--- a/specs/component/00-plan/03-mill-integration.md
+++ b/specs/component/00-plan/03-mill-integration.md
@@ -47,8 +47,8 @@ Explicit `.millhouse/config.local.yaml` overrides (`spawn.worktrees_dir`, `wiki_
 
 ### Card 12: drop `spawn.worktrees_dir` default from `wiki/config.yaml`
 
-- **Reads:** `wiki/config.yaml`, `plugins/mill/scripts/mill-spawn.py` (post-Card-10).
-- **Modifies:** `wiki/config.yaml`
+- **Reads:** `wiki/config.yaml` (accessible as `.millhouse/wiki/config.yaml` from the hub root via the junction, or directly at `<container>/wiki/config.yaml` in the wiki-sibling clone), `plugins/mill/scripts/mill-spawn.py` (post-Card-10).
+- **Modifies:** `wiki/config.yaml` — write to the wiki clone directly. Changes land in the wiki repo's git history, not the hub's. Stage + commit + push via `_wiki.write_commit_push` (standard wiki-write path) OR direct `git -C <container>/wiki` invocation; either is fine since there are no other wiki writers active during this card.
 - **Creates:** (none)
 - **Requirements:**
   - Delete the line `worktrees_dir: <CONTAINER_PATH>/<REPO>.worktrees` from the `spawn:` block.

--- a/specs/component/00-plan/03-mill-integration.md
+++ b/specs/component/00-plan/03-mill-integration.md
@@ -10,40 +10,44 @@ depends-on: [foundation]
 
 ## Batch Scope
 
-Rewire `mill-spawn` and `mill-setup` to call `_sibling.resolve_path` for their default sibling locations. Remove the token-template defaults from `wiki/config.yaml` (`<REPO>.worktrees`, `<REPO>.wiki/` documented default) so the helper is the single source of truth. Update the two integration-test fixtures (`test-spawn.py`, `test-merge.py`) to the new hub-form layout: test repo is named `hub/` so siblings become `worktrees/` and `wiki/` without the prefix.
+Rewire `mill-spawn.py` and the `mill-setup` skill to call `_sibling.resolve_path` for their default sibling locations. Remove the token-template defaults from `wiki/config.yaml` so the helper is the single source of truth. Update the two integration-test fixtures (`test-spawn.py`, `test-merge.py`) to the new hub-form layout: test repo is named `hub/` so siblings become `worktrees/` and `wiki/` without the prefix.
 
 Explicit `.millhouse/config.local.yaml` overrides (`spawn.worktrees_dir`, `wiki_path:`) continue to short-circuit the helper. Users with exotic setups keep their escape hatch.
 
+**Important:** `mill-setup` is a skill (markdown prose), NOT a Python script. Its default wiki path lives inside the SKILL.md prose and must be fixed there — not in a non-existent `mill-setup.py`. Card 11 handles this.
+
 ## Cards
 
-### Card 8: `mill-spawn.py` uses `_sibling.resolve_path("worktrees", ...)`
+### Card 10: `mill-spawn.py` uses `_sibling.resolve_path("worktrees", ...)`
 
-- **Reads:** `plugins/mill/scripts/mill-spawn.py`, `plugins/mill/scripts/_sibling.py` (post-Card-1), `plugins/mill/scripts/_worktree.py`.
+- **Reads:** `plugins/mill/scripts/mill-spawn.py`, `plugins/mill/scripts/_sibling.py` (post-Card-1), `plugins/mill/scripts/_worktree.py`, `wiki/config.yaml` (current `spawn.worktrees_dir` key).
 - **Modifies:** `plugins/mill/scripts/mill-spawn.py`
 - **Creates:** (none)
 - **Requirements:**
-  - Locate the current `_resolve_worktrees_dir` (or equivalent) function. Replace the `<REPO>.worktrees` token-template default with a direct call to `_sibling.resolve_path("worktrees", git_toplevel)`.
-  - If `.millhouse/config.local.yaml` or wiki `config.yaml` explicitly sets `spawn.worktrees_dir`, that string continues to be token-substituted as today. Helper is only the FALLBACK default.
+  - Locate the existing worktrees-dir resolution logic. Currently it reads `cfg["spawn"]["worktrees_dir"]` as a token template (`<CONTAINER_PATH>/<REPO>.worktrees`) and substitutes. Preserve the override path: if `cfg["spawn"]` explicitly sets `worktrees_dir`, continue to use it as a token template (unchanged).
+  - When the config key is ABSENT (new default path), call `_sibling.resolve_path("worktrees", git_toplevel)` from the imported `_sibling` module. Use the returned Path directly.
   - Import `_sibling` lazily inside the function body to keep existing import order stable.
   - Update the function's docstring to mention the helper and the hub-form rule.
-  - No behaviour change for existing hub-form tests (test-spawn.py seeds `hub/` as repo; default helper returns `<container>/worktrees/`).
+  - No behaviour change for existing hub-form tests once Card 13 drops the seeded `worktrees_dir` key (test-spawn seeds `hub/` as repo; default helper returns `<container>/worktrees/`).
 - **Commit:** `feat(mill-spawn): use _sibling.resolve_path for default worktrees path`
 
-### Card 9: `mill-setup.py` uses `_sibling.resolve_path("wiki", ...)`
+### Card 11: `mill-setup` SKILL.md uses `_sibling.py` CLI for default wiki path
 
-- **Reads:** `plugins/mill/scripts/mill-setup.py`, `plugins/mill/scripts/_sibling.py`, `plugins/mill/scripts/_wiki.py`.
-- **Modifies:** `plugins/mill/scripts/mill-setup.py`
+- **Reads:** `plugins/mill/skills/mill-setup/SKILL.md`, `plugins/mill/scripts/_sibling.py` (post-Card-1), `plugins/mill/scripts/_wiki.py`, `plugins/mill/scripts/_junction.py`, `wiki/config.yaml` (the `<WIKI_PATH>` comment block and `junctions:` section).
+- **Modifies:** `plugins/mill/skills/mill-setup/SKILL.md`
 - **Creates:** (none)
 - **Requirements:**
-  - Find the current logic that defaults `wiki_path:` to `<CONTAINER_PATH>/<REPO>.wiki/`. Replace with `_sibling.resolve_path("wiki", git_toplevel)` when the key is absent in `.millhouse/config.local.yaml`.
-  - Explicit `wiki_path:` overrides the helper — unchanged.
-  - Docstring update.
-  - If mill-setup's implementation does NOT currently carry a wiki_path default (only reads from config), this card is a no-op: document that the helper is available and leave behaviour unchanged.
-- **Commit:** `feat(mill-setup): use _sibling.resolve_path for default wiki path`
+  - **The skill currently has internally-inconsistent wiki-path defaults.** Phase 3 reads: *"If `<container>/wiki/` does not exist: `git clone <wiki-url> <container>/wiki`"* — hardcoded hub-form. Phase 3.5 reads: *"`<WIKI_PATH>` — the wiki clone. Default: `<CONTAINER_PATH>/<REPO>.wiki/`"* — prefix-form. Both must become `_sibling.resolve_path("wiki", <hub-path>)`.
+  - **Reconcile Phase 3:** Replace the hardcoded `<container>/wiki` with a computed path. Just before Phase 3, insert an explicit step: "Compute `<wiki-dir>` by invoking `python ${CLAUDE_PLUGIN_ROOT}/scripts/_sibling.py wiki <hub-path>`. Use the printed path as `<wiki-dir>` in Phases 3, 3.5, and 4."
+  - **Reconcile Phase 3.5:** Update the `<WIKI_PATH>` bullet from *"Default: `<CONTAINER_PATH>/<REPO>.wiki/`"* to *"Default: the path computed by `_sibling.py wiki <hub-path>` above (hub-form → `<CONTAINER_PATH>/wiki/`; prefix-form → `<CONTAINER_PATH>/<REPO>.wiki/`). Override if `.millhouse/config.local.yaml` has a `wiki_path:` key."*
+  - Preserve the existing `---` YAML frontmatter unchanged.
+  - Preserve `wiki_path:` override semantics: if `.millhouse/config.local.yaml` sets it, that value wins over the helper's default.
+  - Do NOT introduce any dependency on the mill scripts being importable from the skill (the skill is invoked where mill plugin IS installed, so `${CLAUDE_PLUGIN_ROOT}` is guaranteed).
+- **Commit:** `feat(mill-setup): SKILL uses _sibling.py CLI for default wiki path`
 
-### Card 10: drop `spawn.worktrees_dir` default from `wiki/config.yaml`
+### Card 12: drop `spawn.worktrees_dir` default from `wiki/config.yaml`
 
-- **Reads:** `wiki/config.yaml`, `plugins/mill/scripts/mill-spawn.py` (post-Card-8).
+- **Reads:** `wiki/config.yaml`, `plugins/mill/scripts/mill-spawn.py` (post-Card-10).
 - **Modifies:** `wiki/config.yaml`
 - **Creates:** (none)
 - **Requirements:**
@@ -53,22 +57,22 @@ Explicit `.millhouse/config.local.yaml` overrides (`spawn.worktrees_dir`, `wiki_
   - Remove the obsolete `<WIKI_PATH>` documented default from the `junctions` block's header comment — replace with: "Default: `_sibling.resolve_path('wiki', repo_root)`."
 - **Commit:** `config: drop worktrees_dir default; delegate to _sibling helper`
 
-### Card 11: `test-spawn.py` aligns fixture to new layout
+### Card 13: `test-spawn.py` aligns fixture to new layout
 
-- **Reads:** `plugins/mill/integration_tests/test-spawn.py`, `plugins/mill/scripts/mill-spawn.py` (post-Card-8).
+- **Reads:** `plugins/mill/integration_tests/test-spawn.py`, `plugins/mill/scripts/mill-spawn.py` (post-Card-10).
 - **Modifies:** `plugins/mill/integration_tests/test-spawn.py`
 - **Creates:** (none)
 - **Requirements:**
-  - The test's seeded wiki `config.yaml` currently includes `worktrees_dir: <CONTAINER_PATH>/<REPO>.worktrees`. After Card 10 this default is gone — the test must either continue to seed it explicitly (if we want to test the override path) or drop it (if we want to test the new default).
+  - The test's seeded wiki `config.yaml` currently includes `worktrees_dir: <CONTAINER_PATH>/<REPO>.worktrees`. After Card 12 this default is gone — the test either continues to seed it explicitly (to exercise the override path) or drops it (to exercise the new default).
   - **Chosen:** drop the `spawn.worktrees_dir` line from the seeded config. Test the new default behaviour.
   - Update the assertion that checks the worktree path: expect `<container>/worktrees/<slug>/` (not `<container>/hub.worktrees/<slug>/`).
   - Similarly update any variable named `worktrees_dir` in the test body. Search for `hub.worktrees` literal strings and replace.
   - Keep the remaining fixture + assertions untouched.
 - **Commit:** `test(spawn): update fixture to hub-form default (worktrees/ not hub.worktrees/)`
 
-### Card 12: `test-merge.py` aligns fixture to new layout
+### Card 14: `test-merge.py` aligns fixture to new layout
 
-- **Reads:** `plugins/mill/integration_tests/test-merge.py`, `plugins/mill/scripts/mill-spawn.py` (post-Card-8), `plugins/mill/integration_tests/test-spawn.py` (post-Card-11).
+- **Reads:** `plugins/mill/integration_tests/test-merge.py`, `plugins/mill/scripts/mill-spawn.py` (post-Card-10), `plugins/mill/integration_tests/test-spawn.py` (post-Card-13).
 - **Modifies:** `plugins/mill/integration_tests/test-merge.py`
 - **Creates:** (none)
 - **Requirements:**

--- a/specs/component/00-plan/03-mill-integration.md
+++ b/specs/component/00-plan/03-mill-integration.md
@@ -1,0 +1,87 @@
+# Batch: mill-integration
+
+```yaml
+task: codeguide sibling-mode + unified sibling-path convention
+batch: mill-integration
+cards: 5
+verify: python plugins/mill/integration_tests/test-spawn.py && python plugins/mill/integration_tests/test-merge.py
+depends-on: [foundation]
+```
+
+## Batch Scope
+
+Rewire `mill-spawn` and `mill-setup` to call `_sibling.resolve_path` for their default sibling locations. Remove the token-template defaults from `wiki/config.yaml` (`<REPO>.worktrees`, `<REPO>.wiki/` documented default) so the helper is the single source of truth. Update the two integration-test fixtures (`test-spawn.py`, `test-merge.py`) to the new hub-form layout: test repo is named `hub/` so siblings become `worktrees/` and `wiki/` without the prefix.
+
+Explicit `.millhouse/config.local.yaml` overrides (`spawn.worktrees_dir`, `wiki_path:`) continue to short-circuit the helper. Users with exotic setups keep their escape hatch.
+
+## Cards
+
+### Card 8: `mill-spawn.py` uses `_sibling.resolve_path("worktrees", ...)`
+
+- **Reads:** `plugins/mill/scripts/mill-spawn.py`, `plugins/mill/scripts/_sibling.py` (post-Card-1), `plugins/mill/scripts/_worktree.py`.
+- **Modifies:** `plugins/mill/scripts/mill-spawn.py`
+- **Creates:** (none)
+- **Requirements:**
+  - Locate the current `_resolve_worktrees_dir` (or equivalent) function. Replace the `<REPO>.worktrees` token-template default with a direct call to `_sibling.resolve_path("worktrees", git_toplevel)`.
+  - If `.millhouse/config.local.yaml` or wiki `config.yaml` explicitly sets `spawn.worktrees_dir`, that string continues to be token-substituted as today. Helper is only the FALLBACK default.
+  - Import `_sibling` lazily inside the function body to keep existing import order stable.
+  - Update the function's docstring to mention the helper and the hub-form rule.
+  - No behaviour change for existing hub-form tests (test-spawn.py seeds `hub/` as repo; default helper returns `<container>/worktrees/`).
+- **Commit:** `feat(mill-spawn): use _sibling.resolve_path for default worktrees path`
+
+### Card 9: `mill-setup.py` uses `_sibling.resolve_path("wiki", ...)`
+
+- **Reads:** `plugins/mill/scripts/mill-setup.py`, `plugins/mill/scripts/_sibling.py`, `plugins/mill/scripts/_wiki.py`.
+- **Modifies:** `plugins/mill/scripts/mill-setup.py`
+- **Creates:** (none)
+- **Requirements:**
+  - Find the current logic that defaults `wiki_path:` to `<CONTAINER_PATH>/<REPO>.wiki/`. Replace with `_sibling.resolve_path("wiki", git_toplevel)` when the key is absent in `.millhouse/config.local.yaml`.
+  - Explicit `wiki_path:` overrides the helper — unchanged.
+  - Docstring update.
+  - If mill-setup's implementation does NOT currently carry a wiki_path default (only reads from config), this card is a no-op: document that the helper is available and leave behaviour unchanged.
+- **Commit:** `feat(mill-setup): use _sibling.resolve_path for default wiki path`
+
+### Card 10: drop `spawn.worktrees_dir` default from `wiki/config.yaml`
+
+- **Reads:** `wiki/config.yaml`, `plugins/mill/scripts/mill-spawn.py` (post-Card-8).
+- **Modifies:** `wiki/config.yaml`
+- **Creates:** (none)
+- **Requirements:**
+  - Delete the line `worktrees_dir: <CONTAINER_PATH>/<REPO>.worktrees` from the `spawn:` block.
+  - Update the preceding comment to describe the new behaviour: "`worktrees_dir` (optional) — absolute path or `<CONTAINER_PATH>/<REPO>.worktrees`-style template to override the default `_sibling.resolve_path('worktrees', repo_root)`. Omit to use the default (hub-form-aware)."
+  - Leave `branch_prefix` unchanged.
+  - Remove the obsolete `<WIKI_PATH>` documented default from the `junctions` block's header comment — replace with: "Default: `_sibling.resolve_path('wiki', repo_root)`."
+- **Commit:** `config: drop worktrees_dir default; delegate to _sibling helper`
+
+### Card 11: `test-spawn.py` aligns fixture to new layout
+
+- **Reads:** `plugins/mill/integration_tests/test-spawn.py`, `plugins/mill/scripts/mill-spawn.py` (post-Card-8).
+- **Modifies:** `plugins/mill/integration_tests/test-spawn.py`
+- **Creates:** (none)
+- **Requirements:**
+  - The test's seeded wiki `config.yaml` currently includes `worktrees_dir: <CONTAINER_PATH>/<REPO>.worktrees`. After Card 10 this default is gone — the test must either continue to seed it explicitly (if we want to test the override path) or drop it (if we want to test the new default).
+  - **Chosen:** drop the `spawn.worktrees_dir` line from the seeded config. Test the new default behaviour.
+  - Update the assertion that checks the worktree path: expect `<container>/worktrees/<slug>/` (not `<container>/hub.worktrees/<slug>/`).
+  - Similarly update any variable named `worktrees_dir` in the test body. Search for `hub.worktrees` literal strings and replace.
+  - Keep the remaining fixture + assertions untouched.
+- **Commit:** `test(spawn): update fixture to hub-form default (worktrees/ not hub.worktrees/)`
+
+### Card 12: `test-merge.py` aligns fixture to new layout
+
+- **Reads:** `plugins/mill/integration_tests/test-merge.py`, `plugins/mill/scripts/mill-spawn.py` (post-Card-8), `plugins/mill/integration_tests/test-spawn.py` (post-Card-11).
+- **Modifies:** `plugins/mill/integration_tests/test-merge.py`
+- **Creates:** (none)
+- **Requirements:**
+  - Change `worktrees_dir = container / "hub.worktrees"` to `worktrees_dir = container / "worktrees"` in `_setup_trio`.
+  - Update the hub-config seeded inside `_setup_trio` to drop the `spawn.worktrees_dir` line.
+  - Update any assertion referencing the worktree path.
+  - Everything else (Home.md flip, junction cleanup, merge lock) stays unchanged.
+- **Commit:** `test(merge): update fixture to hub-form default`
+
+## Batch Tests
+
+Batch verify runs `test-spawn.py` and `test-merge.py` end-to-end. Both exercise the new path helper through real git ops. Pass criteria: both tests exit 0 with no assertion failures and no stray `hub.worktrees/` or `<repo>.worktrees/` paths in output.
+
+Run order is sequential — `test-spawn.py` first (foundation for the layout), `test-merge.py` second (depends on spawn-style worktrees).
+
+If either test fails, the implementer self-fixes up to `review.code.self_fix_rounds` attempts (2 per default config) before reporting stuck.

--- a/specs/component/00-plan/04-docs.md
+++ b/specs/component/00-plan/04-docs.md
@@ -1,0 +1,33 @@
+# Batch: docs
+
+```yaml
+task: codeguide sibling-mode + unified sibling-path convention
+batch: docs
+cards: 1
+verify: null
+depends-on: [mill-integration, codeguide-plugin]
+```
+
+## Batch Scope
+
+One small documentation edit that lands after both behaviour-changing batches are in: the placeholder spec `13-mill-codeguide.md` needs to learn that codeguide can live either inline or sibling. It currently assumes inline only (written when sibling didn't exist yet). A single sentence edit keeps that spec accurate so future implementers don't re-derive the design.
+
+No code changes here; no verify command.
+
+## Cards
+
+### Card 13: update `13-mill-codeguide.md` to mention sibling mode
+
+- **Reads:** `specs/component/13-mill-codeguide.md`, `specs/component/00-codeguide-sibling-mode.md` (post-implementation), `plugins/codeguide/skills/codeguide-setup/SKILL.md` (post-Card-5).
+- **Modifies:** `specs/component/13-mill-codeguide.md`
+- **Creates:** (none)
+- **Requirements:**
+  - In the `## Mechanism (already partially designed)` section, update the bullet describing where codeguide lives. Currently it implicitly assumes inline. Change to: "codeguide can live either inline (`<repo>/_codeguide/`) or in a sibling repo (`<parent>/codeguide/` for hub-form, `<parent>/<repo>.codeguide/` otherwise). `resolve.py` handles both transparently — the consuming skill doesn't care."
+  - In the `## Scope when implemented` section, update step 1 to note the same choice: "Write the seed `_codeguide/Overview.md` (inline or sibling, as Henrik prefers for the hub at that time)."
+  - Do not change the deferral rationale — the spec is still gated on mill-v2 self-sufficiency.
+  - One-line commit message tying this to spec 00.
+- **Commit:** `spec: 13-mill-codeguide mentions sibling mode (closes spec 00)`
+
+## Batch Tests
+
+None. Pure documentation. Manual spot-check via `git diff` at commit time is sufficient.

--- a/specs/component/00-plan/04-docs.md
+++ b/specs/component/00-plan/04-docs.md
@@ -16,9 +16,9 @@ No code changes here; no verify command.
 
 ## Cards
 
-### Card 13: update `13-mill-codeguide.md` to mention sibling mode
+### Card 15: update `13-mill-codeguide.md` to mention sibling mode
 
-- **Reads:** `specs/component/13-mill-codeguide.md`, `specs/component/00-codeguide-sibling-mode.md` (post-implementation), `plugins/codeguide/skills/codeguide-setup/SKILL.md` (post-Card-5).
+- **Reads:** `specs/component/13-mill-codeguide.md`, `specs/component/00-codeguide-sibling-mode.md` (post-implementation), `plugins/codeguide/skills/codeguide-setup/SKILL.md` (post-Card-7).
 - **Modifies:** `specs/component/13-mill-codeguide.md`
 - **Creates:** (none)
 - **Requirements:**

--- a/specs/component/00-plan/reviews/20260423-plan-review-r1.md
+++ b/specs/component/00-plan/reviews/20260423-plan-review-r1.md
@@ -1,0 +1,40 @@
+# Review: codeguide sibling-mode + unified sibling-path convention — holistic
+
+```yaml
+verdict: REQUEST_CHANGES
+reviewer_model: sonnet-4-6 (via Agent tool)
+reviewed_file: specs/component/00-plan/
+date: 2026-04-23
+```
+
+## Findings
+
+### [BLOCKING] `mill-setup.py` does not exist
+**Location:** Batch mill-integration / Card 9; plan's "All Files Touched" list
+**Issue:** Card 9 modifies `plugins/mill/scripts/mill-setup.py`, but no such file exists — only `mill-spawn.py`, `mill-add.py`, `mill-list.py`, `mill-review-*.py`, and `mill-skills-index.py` are present. The card already hedges ("if mill-setup's implementation does NOT currently carry a wiki_path default… this card is a no-op"), but a no-op card against a non-existent file misleads the implementer and silently skips a real behaviour gap.
+**Fix:** Either confirm `mill-setup.py` does not exist (remove the card and document where the wiki-path default actually lives — likely in mill-spawn or a helper — so the spec's intent is still covered), or create the script as a prerequisite card.
+
+### [BLOCKING] `resolve.py` on-disk path diverges from every plan/skill reference
+**Location:** Batch codeguide-plugin / Cards 3, 4, 6; Batch docs / Card 13
+**Issue:** The file on disk is `plugins/codeguide/scripts/resolve.py`. Every existing skill (`codeguide-setup`, `codeguide-update`, `codeguide-generate`, `codeguide-maintain`) invokes it as `${CLAUDE_PLUGIN_ROOT}/scripts/millpy/codeguide/resolve.py`. The plan creates `codeguide_commit.py` alongside it at `plugins/codeguide/scripts/millpy/codeguide/codeguide_commit.py` — a directory that does not exist. Running any skill today would fail at that `python` call. The plan must reconcile this: either move/copy `resolve.py` to `scripts/millpy/codeguide/` (making the skills correct) or update all skill references to `scripts/resolve.py`. This also affects Card 3's import path for `_sibling.py` from the codeguide plugin.
+**Fix:** Add a Card 0 (or first card of codeguide-plugin batch) that moves `resolve.py` to `plugins/codeguide/scripts/millpy/codeguide/resolve.py` and creates the `millpy/codeguide/` package. All downstream cards then write to a real path. Alternatively, flatten: keep `resolve.py` at `scripts/` and place `codeguide_commit.py` there too, and fix all skill references in the same card.
+
+### [BLOCKING] Cross-plugin import in Card 3 is not `${CLAUDE_PLUGIN_ROOT}`-safe
+**Location:** Batch codeguide-plugin / Card 3
+**Issue:** Card 3 requires `resolve.py` to import `_sibling.py` via `${CLAUDE_PLUGIN_ROOT}/../mill/scripts/_sibling.py` — a relative navigation from the codeguide plugin root into the mill plugin. The spec's own hard rule ("All plugin scripts reference `${CLAUDE_PLUGIN_ROOT}` for intra-plugin paths. Never assume millhouse source is cloned.") means `../mill/` is only valid if both plugins always install in sibling directories. Plugin install location is not guaranteed. The spec calls `_sibling.py` "consumed by… codeguide `resolve.py`" but gives no safe cross-plugin call convention.
+**Fix:** Instead of importing `_sibling.py` directly, have `resolve.py` call `python ${MILL_PLUGIN_ROOT}/scripts/_sibling.py` as a subprocess (role + repo-root as CLI args), or expose `_sibling`'s logic as a tiny inline fallback function in `resolve.py` that duplicates the three-line rule (acceptable since it is pure arithmetic with no future divergence risk). Document which approach is chosen.
+
+### [NIT] Card 5 writes `mode:` into Overview.md frontmatter — not in spec decisions
+**Location:** Batch codeguide-plugin / Card 5
+**Issue:** "Mode the skill writes into the overview's frontmatter: `mode: inline | sibling`. Resolve.py reads this as a cross-check." This field does not appear anywhere in the spec's decisions. The spec's resolve chain is deterministic from the file-system walk; it needs no stored mode flag.
+**Fix:** Drop the frontmatter requirement unless the implementer has a concrete reason to store it. If kept, add a spec decision entry explaining the cross-check purpose and what happens when the stored value disagrees with the walk result.
+
+### [NIT] `codeguide-setup` SKILL.md uses `---` YAML frontmatter — plan must preserve it
+**Location:** Batch codeguide-plugin / Card 5
+**Issue:** The existing `codeguide-setup/SKILL.md` has `---` frontmatter (confirmed on disk). The markdown skill convention only forbids `---` in *generated* docs; `SKILL.md` files are explicitly allowed to use it. The card says "rewrite" — ensure the implementer preserves the `---` block and only edits the body.
+**Fix:** Add a bullet to Card 5 requirements: "Preserve the existing `---` YAML frontmatter header (`name:`, `description:`, `argument-hint:`). Update `argument-hint:` to include `[--sibling] [--from-url <git-url>]`."
+
+## Verdict
+
+REQUEST_CHANGES
+Two path-grounding BLOCKINGs (missing `mill-setup.py`, wrong `resolve.py` directory) and one design-safety BLOCKING (cross-plugin import) must be resolved before implementation.

--- a/specs/component/00-plan/reviews/20260423-plan-review-r2.md
+++ b/specs/component/00-plan/reviews/20260423-plan-review-r2.md
@@ -1,0 +1,25 @@
+# Review: codeguide sibling-mode + unified sibling-path convention — holistic r2
+
+```yaml
+verdict: APPROVE
+reviewer_model: sonnet-4-6 (via Agent tool)
+reviewed_file: specs/component/00-plan/
+date: 2026-04-23
+```
+
+## Findings
+
+### [NIT] `codeguide_commit.py` mode-detection is ambiguous
+**Location:** Batch codeguide-plugin / Card 6
+**Issue:** Card 6 says the helper should "call `resolve.py` (or directly import its logic) to determine mode," but `codeguide_commit.py`'s CLI only accepts `--file` and `-m` — it has no `--mode` or `--sibling-anchor` arg. The caller (`codeguide-update`) already holds the `resolve.py` result at that point; making the helper re-run resolution from cwd is fragile if cwd differs from the repo root.
+**Fix:** Add `--mode inline|sibling` and `--sibling-anchor <path>` to the CLI args. The caller passes what it already knows; the helper trusts those args and never calls `resolve.py` itself.
+
+### [NIT] `wiki/config.yaml` path never clarified for the implementer
+**Location:** Batch mill-integration / Cards 10, 11, 12; overview "All Files Touched"
+**Issue:** The plan consistently refers to `wiki/config.yaml` as if it is a path relative to the hub, but the file lives in the wiki repo (confirmed at `C:/Code/millhouse/wiki/config.yaml`). The `.millhouse/wiki` junction makes it reachable as `.millhouse/wiki/config.yaml` from hub root, but an implementer following the plan literally will not find `wiki/config.yaml` by path from cwd.
+**Fix:** Add a one-line note to Card 12's "Reads" bullet: "Accessible as `.millhouse/wiki/config.yaml` from the hub root via the junction, or directly at `<container>/wiki/config.yaml`."
+
+## Verdict
+
+APPROVE
+All three r1 BLOCKINGs are resolved; two minor NITs remain but do not block implementation.

--- a/specs/component/13-mill-codeguide.md
+++ b/specs/component/13-mill-codeguide.md
@@ -7,11 +7,11 @@ status: placeholder — deferred until mill-v2 is self-sufficient enough to run 
 note: "The codeguide plugin is already shipped (plugins/codeguide/) with codeguide-setup/-generate/-update/-maintain. The hub repo just hasn't been seeded. Do not seed manually."
 ```
 
-**For the thread that will eventually run this:** the infrastructure is done; there is no code to write. The one-shot sequence is:
+**For the thread that will eventually run this:** the infrastructure is done; there is no code to write. Codeguide can live either **inline** (`<repo>/_codeguide/`) or in a **sibling** repo (`<container>/codeguide/` for hub-form, `<container>/<repo>.codeguide/` otherwise). `resolve.py` handles both transparently — the consuming skill doesn't care. The one-shot sequence is:
 
-1. From hub root: invoke `/codeguide-setup` — creates `_codeguide/Overview.md`, `config.yaml`, `modules/DocumentationGuide.md`, etc.
+1. From hub root: invoke `/codeguide-setup` (inline) or `/codeguide-setup --sibling` (sibling, as Henrik prefers for the hub at that time) — seeds the `_codeguide/` tree in the chosen location.
 2. Optionally `/codeguide-generate` to bulk-document existing source files.
-3. Commit the seeded `_codeguide/` tree.
+3. Commit the seeded `_codeguide/` tree (inline → inside the hub; sibling → its own history in the sibling repo).
 
 From that point on, every `/git-commit` invocation triggers the pre-commit "Codeguide sync" step, which calls `@codeguide:codeguide-update` against the staged diff. Docs stay fresh per-commit.
 

--- a/specs/component/done-00-codeguide-sibling-mode.md
+++ b/specs/component/done-00-codeguide-sibling-mode.md
@@ -4,10 +4,12 @@
 type: plugin change (codeguide) + _sibling.py helper + mill-config unification
 layer: bookkeeping / external tooling
 v1_ref: none — new capability
-status: discussed — ready for plan-writing
+status: done — merged to main 2026-04-23 (branch impl/00-codeguide-sibling-mode)
 note: "Let `_codeguide/` live in a sibling git repo next to the target repo. Same hub-form detection rule (`repo/.name == 'hub'`) unifies the naming convention across wiki, worktrees, and codeguide. Zero-footprint inside the target repo. Mill-v2 skill-contracts unaffected."
 priority: run before specs 07+. Triggered by the engineer's upcoming work on a third-party codebase where `_codeguide/` files cannot live in the main repo.
 ```
+
+**Implementation notes:** `plugins/mill/scripts/_sibling.py` + `plugins/codeguide/scripts/_sibling.py` (identical twins) expose `resolve_path(role, repo_root)` plus a CLI. `mill-spawn.py` and `mill-setup` SKILL.md delegate to the mill copy for default worktrees/ and wiki/ paths; explicit `.millhouse/config.local.yaml` overrides still win. `plugins/codeguide/scripts/resolve.py` gained a 3-step resolve chain (inline walk → `.codeguide-root` at git-toplevel → sibling via local `_sibling`) returning `{mode, cg_root, sibling_anchor, found}` via `--json`. `plugins/codeguide/scripts/codeguide_commit.py` is mode-aware (inline → `git add`; sibling → `git -C <anchor> add/commit`). `codeguide-setup` SKILL.md gained `--sibling [--from-url <url>]` flags; `codeguide-update` groups files by cg-root and calls `codeguide_commit.py` with per-group `--mode`/`--sibling-anchor`. Stale `millpy/codeguide/resolve.py` paths fixed across all four codeguide SKILLs. `wiki/config.yaml` dropped the `spawn.worktrees_dir` default and updated the `<WIKI_PATH>` comment. Unit test `test-sibling.py` covers all role×name combos and CLI; `test-spawn.py`/`test-merge.py` fixtures seed the hub-form default. Verify (unit + 4 integration tests) passes.
 
 ## Scope summary (post-discussion)
 


### PR DESCRIPTION
## Summary

- Adds `_sibling.py` helper (mill + codeguide, identical twins) that maps `(role, repo_root)` to canonical sibling paths. Hub-form (`repo_root.name == "hub"` exact) → `<container>/<role>/`; prefix-form → `<container>/<repo>.<role>/`.
- Codeguide plugin gains **sibling mode**: `/codeguide-setup --sibling [--from-url <url>]` creates a separate sibling git repo; `resolve.py` walks inline → `.codeguide-root` → sibling anchor. `codeguide_commit.py` is mode-aware (inline stages only; sibling stages + commits in the sibling repo).
- Mill-spawn + mill-setup delegate default worktrees/wiki paths to `_sibling.resolve_path`. Explicit `.millhouse/config.local.yaml` overrides still short-circuit. The `spawn.worktrees_dir` default is removed from `wiki/config.yaml` (wiki commit pending push).
- Fixes pre-existing bug: four codeguide SKILL.md files referenced the non-existent path `${CLAUDE_PLUGIN_ROOT}/scripts/millpy/codeguide/resolve.py`. Corrected to `scripts/resolve.py`.

## Plan & reviews

- Plan under `specs/component/00-plan/` — 4 batches, 15 cards.
- Plan review r2: APPROVE (sonnet-4-6 via Agent tool).
- Spec marked done + renamed to `done-00-codeguide-sibling-mode.md`.

## Wiki repo change (not in this PR)

`wiki/config.yaml` lives in the separate wiki repo at `C:/Code/millhouse/wiki/`. Matching commit (`config: drop worktrees_dir default; delegate to _sibling helper`) landed there locally but NOT pushed yet.
